### PR TITLE
RevealEntryReponse Json field change

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -343,7 +343,7 @@ func CommitEntry(e *Entry, name string) error {
 
 type RevealEntryResponse struct {
 	Message string `json:"message"`
-	TxID    string `json:"txid"`
+	TxID    string `json:"entryhash"`
 }
 
 func RevealEntry(e *Entry) (*RevealEntryResponse, error) {


### PR DESCRIPTION
The json field "txid" was changed to "entryhash" as reveal now returns an entryhash instead