### PR TITLE
Marshal/Unmarshal did not match byte length for Addresses

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -133,7 +133,7 @@ func (a *ECAddress) UnmarshalBinaryData(data []byte) ([]byte, error) {
 }
 
 func (a *ECAddress) MarshalBinary() ([]byte, error) {
-	return a.SecBytes(), nil
+	return a.SecBytes()[:32], nil
 }
 
 // GetECAddress takes a private address string (Es...) and returns an ECAddress.
@@ -266,7 +266,7 @@ func (t *FactoidAddress) UnmarshalBinaryData(data []byte) ([]byte, error) {
 }
 
 func (t *FactoidAddress) MarshalBinary() ([]byte, error) {
-	return t.SecBytes(), nil
+	return t.SecBytes()[:32], nil
 }
 
 // GetFactoidAddress takes a private address string (Fs...) and returns a

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -49,7 +49,7 @@ func TestMarshalAddresses(t *testing.T) {
 		}
 
 		if bytes.Compare(ec.PubBytes(), ec2.PubBytes()) != 0 {
-			t.Errorf("Unmarshaled object has different secret.")
+			t.Errorf("Unmarshaled object has different public.")
 		}
 	}
 
@@ -85,7 +85,7 @@ func TestMarshalAddresses(t *testing.T) {
 		}
 
 		if bytes.Compare(fa.PubBytes(), fa2.PubBytes()) != 0 {
-			t.Errorf("Unmarshaled object has different secret.")
+			t.Errorf("Unmarshaled object has different public.")
 		}
 	}
 }

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -5,6 +5,7 @@
 package factom_test
 
 import (
+	"crypto/rand"
 	"testing"
 
 	ed "github.com/FactomProject/ed25519"
@@ -13,6 +14,64 @@ import (
 )
 
 var ()
+
+func TestMarshalAddresses(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		sec := make([]byte, 32)
+		_, err := rand.Read(sec)
+		if err != nil {
+			t.Error(err)
+		}
+
+		ec, err := MakeECAddress(sec)
+		if err != nil {
+			t.Error(err)
+		}
+
+		data, err := ec.MarshalBinary()
+		if err != nil {
+			t.Error(err)
+		}
+
+		ec2 := new(ECAddress)
+		newdata, err := ec2.UnmarshalBinaryData(data)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(newdata) != 0 {
+			t.Errorf("UnmarshalBinary left %d bytes remaining", len(newdata))
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		sec := make([]byte, 32)
+		_, err := rand.Read(sec)
+		if err != nil {
+			t.Error(err)
+		}
+
+		fa, err := MakeFactoidAddress(sec)
+		if err != nil {
+			t.Error(err)
+		}
+
+		data, err := fa.MarshalBinary()
+		if err != nil {
+			t.Error(err)
+		}
+
+		fa2 := new(FactoidAddress)
+		newdata, err := fa2.UnmarshalBinaryData(data)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(newdata) != 0 {
+			t.Errorf("UnmarshalBinary left %d bytes remaining", len(newdata))
+		}
+	}
+}
 
 func TestAddressStringType(t *testing.T) {
 	var (

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -5,6 +5,7 @@
 package factom_test
 
 import (
+	"bytes"
 	"crypto/rand"
 	"testing"
 
@@ -42,6 +43,14 @@ func TestMarshalAddresses(t *testing.T) {
 		if len(newdata) != 0 {
 			t.Errorf("UnmarshalBinary left %d bytes remaining", len(newdata))
 		}
+
+		if bytes.Compare(ec.SecBytes(), ec2.SecBytes()) != 0 {
+			t.Errorf("Unmarshaled object has different secret.")
+		}
+
+		if bytes.Compare(ec.PubBytes(), ec2.PubBytes()) != 0 {
+			t.Errorf("Unmarshaled object has different secret.")
+		}
 	}
 
 	for i := 0; i < 100; i++ {
@@ -69,6 +78,14 @@ func TestMarshalAddresses(t *testing.T) {
 
 		if len(newdata) != 0 {
 			t.Errorf("UnmarshalBinary left %d bytes remaining", len(newdata))
+		}
+
+		if bytes.Compare(fa.SecBytes(), fa2.SecBytes()) != 0 {
+			t.Errorf("Unmarshaled object has different secret.")
+		}
+
+		if bytes.Compare(fa.PubBytes(), fa2.PubBytes()) != 0 {
+			t.Errorf("Unmarshaled object has different secret.")
 		}
 	}
 }


### PR DESCRIPTION
Marshal/Unmarshal did not match byte length for Addresses. Also added a test to verify

Unmarshal was only taking 32 bytes, while the marshal was returning 64. This makes them both only do 32