### PR TITLE
EntryAck is now split into EntryCommitAck and EntryRevealAck

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -216,6 +216,7 @@ func CommitEntry(e *Entry, ec *ECAddress) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	if resp.Error != nil {
 		return "", resp.Error
 	}

--- a/wsapistructs.go
+++ b/wsapistructs.go
@@ -13,7 +13,8 @@ type heightRequest struct {
 }
 
 type ackRequest struct {
-	TxID            string `json:"txid,omitempty"`
+	Hash            string `json:"hash,omitempty"`
+	ChainID         string `json:"chainid,omitempty"`
 	FullTransaction string `json:"fulltransaction,omitempty"`
 }
 


### PR DESCRIPTION
EntryAck is now split into EntryCommitAck and EntryRevealAck using new `ack` api call

The old call stil exists for legacy support, but should not be used.