### PR TITLE
Fd 128

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -216,6 +216,7 @@ func CommitEntry(e *Entry, ec *ECAddress) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	if resp.Error != nil {
 		return "", resp.Error
 	}

--- a/get.go
+++ b/get.go
@@ -6,6 +6,8 @@ package factom
 
 import (
 	"encoding/json"
+
+	"fmt"
 )
 
 // GetECBalance returns the balance in factoshi (factoid * 1e8) of a given Entry
@@ -248,6 +250,10 @@ func GetAllChainEntries(chainid string) ([]*Entry, error) {
 		return es, err
 	}
 
+	if head == "" {
+		return nil, fmt.Errorf("Chain not yet included in a Directory Block")
+	}
+
 	for ebhash := head; ebhash != ZeroHash; {
 		eb, err := GetEBlock(ebhash)
 		if err != nil {
@@ -271,6 +277,10 @@ func GetFirstEntry(chainid string) (*Entry, error) {
 	head, err := GetChainHead(chainid)
 	if err != nil {
 		return e, err
+	}
+
+	if head == "" {
+		return nil, fmt.Errorf("Chain not yet included in a Directory Block")
 	}
 
 	eb, err := GetEBlock(head)

--- a/wsapistructs.go
+++ b/wsapistructs.go
@@ -13,7 +13,8 @@ type heightRequest struct {
 }
 
 type ackRequest struct {
-	TxID            string `json:"txid,omitempty"`
+	Hash            string `json:"hash,omitempty"`
+	ChainID         string `json:"chainid,omitempty"`
 	FullTransaction string `json:"fulltransaction,omitempty"`
 }
 


### PR DESCRIPTION
When doing GetAllEntries or GetFirstEntry, the return was "Invalid Hash", as the chainhead was an empty string. This is because it was in the process list, but not in a block. This catches that, and returns an error, since there isn't any entries yet.

This error propagates to the cli, and gives the user a better error, as the existing error indicates an error in the input, when there is none