### PR TITLE
Allow a user to set a Timeout for HTTP requests

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type RPCConfig struct {
@@ -27,6 +28,8 @@ type RPCConfig struct {
 	FactomdRPCPassword string
 	FactomdServer      string
 	WalletServer       string
+	WalletTimeout      time.Duration
+	FactomdTimeout     time.Duration
 }
 
 func EncodeJSON(data interface{}) ([]byte, error) {
@@ -150,6 +153,22 @@ func GetFactomdEncryption() (bool, string) {
 	return RpcConfig.FactomdTLSEnable, RpcConfig.FactomdTLSCertFile
 }
 
+func SetFactomdTimeout(timeout time.Duration) {
+	RpcConfig.FactomdTimeout = timeout
+}
+
+func GetFactomdTimeout() time.Duration {
+	return RpcConfig.FactomdTimeout
+}
+
+func SetWalletTimeout(timeout time.Duration) {
+	RpcConfig.WalletTimeout = timeout
+}
+
+func GetWalletTimeout() time.Duration {
+	return RpcConfig.WalletTimeout
+}
+
 func SetWalletRpcConfig(user string, password string) {
 	RpcConfig.WalletRPCUser = user
 	RpcConfig.WalletRPCPassword = password
@@ -213,11 +232,11 @@ func factomdRequest(req *JSON2Request) (*JSON2Response, error) {
 		caCertPool.AppendCertsFromPEM(caCert)
 		tr := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caCertPool}}
 
-		client = &http.Client{Transport: tr}
+		client = &http.Client{Transport: tr, Timeout: GetFactomdTimeout()}
 		httpx = "https"
 
 	} else {
-		client = &http.Client{}
+		client = &http.Client{Timeout: GetFactomdTimeout()}
 		httpx = "http"
 	}
 	re, err := http.NewRequest("POST",
@@ -275,11 +294,11 @@ func walletRequest(req *JSON2Request) (*JSON2Response, error) {
 		caCertPool.AppendCertsFromPEM(caCert)
 		tr := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caCertPool}}
 
-		client = &http.Client{Transport: tr}
+		client = &http.Client{Transport: tr, Timeout: GetWalletTimeout()}
 		httpx = "https"
 
 	} else {
-		client = &http.Client{}
+		client = &http.Client{Timeout: GetWalletTimeout()}
 		httpx = "http"
 	}
 


### PR DESCRIPTION
Previously there was no way for a user to set the `http.Client.Timeout time.Duration` for HTTP requests. This defaulted to 0 resulting in an infinite timeout. Any application depending on this library would require its own timeout mechanism if it needs to know when a factom API call has failed.

This PR adds `FactomdTimeout time.Duration` and `WalletTimeout time.Duration` variables to the `RpcConfig struct`. These variables are used to set the `http.Client.Timeout` when making HTTP requests. 

This also adds the helper functions `SetFactomdTimeout(timeout time.Duration)`, `GetFactomdTimeout() time.Duration`, `SetWalletTimeout(timeout time.Duration)`, and `GetWalletTimeout() time.Duration`.