### PR TITLE
Add top level comments to all exported symbols

### DIFF
--- a/ack.go
+++ b/ack.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 )
 
+// FactoidTxStatus embeds GeneralTransactionData with a transaction ID.
 type FactoidTxStatus struct {
 	TxID string `json:"txid"`
 	GeneralTransactionData
 }
 
+// String satisfies the Stringer interface for FactoidTxStatus and returns a
+// formatted string containing TxID, Status, and TransactionDateString.
 func (f *FactoidTxStatus) String() string {
 	var s string
 	s += fmt.Sprintln("TxID:", f.TxID)
@@ -23,6 +26,8 @@ func (f *FactoidTxStatus) String() string {
 	return s
 }
 
+// EntryStatus represents metadata about an Entry that has been committed and
+// revealed.
 type EntryStatus struct {
 	CommitTxID string `json:"committxid"`
 	EntryHash  string `json:"entryhash"`
@@ -34,6 +39,10 @@ type EntryStatus struct {
 	ConflictingRevealEntryHashes []string      `json:"conflictingrevealentryhashes,omitempty"`
 }
 
+// String satisfies the Stringer interface for EntryStatus and returns a
+// formatted string containing EntryHash, EntryData.Status,
+// EntryData.TransactionDateString, CommitTxID, CommitData.Status,
+// CommitData.TransactionDateString.
 func (e *EntryStatus) String() string {
 	var s string
 	if e.EntryHash != "" {
@@ -48,11 +57,13 @@ func (e *EntryStatus) String() string {
 	return s
 }
 
+// ReserveInfo associates timeout information with a transaction ID.
 type ReserveInfo struct {
 	TxID    string `json:"txid"`
 	Timeout int64  `json:"timeout"` //Unix time
 }
 
+// GeneralTransactionData contains metadata about a transaction.
 type GeneralTransactionData struct {
 	// TransactionDate in Unix time
 	TransactionDate int64 `json:"transactiondate,omitempty"`
@@ -67,11 +78,13 @@ type GeneralTransactionData struct {
 	Status    string     `json:"status"`
 }
 
+// Malleated is a struct that wraps a slice of malleated transaction IDs.
 type Malleated struct {
 	MalleatedTxIDs []string `json:"malleatedtxids"`
 }
 
-// EntryCommitACK takes the txid of the commit and searches for the entry/chain commit
+// EntryCommitACK makes an "ack" RPC request using the txID of the commit to
+// search for the entry OR chain commit.
 func EntryCommitACK(txID, fullTransaction string) (*EntryStatus, error) {
 	params := ackRequest{Hash: txID, ChainID: "c", FullTransaction: fullTransaction}
 	req := NewJSON2Request("ack", APICounter(), params)
@@ -91,6 +104,8 @@ func EntryCommitACK(txID, fullTransaction string) (*EntryStatus, error) {
 	return eb, nil
 }
 
+// FactoidACK makes an "ack" RPC request to check the status of a Factoid
+// transaction.
 func FactoidACK(txID, fullTransaction string) (*FactoidTxStatus, error) {
 	params := ackRequest{Hash: txID, ChainID: "f", FullTransaction: fullTransaction}
 	req := NewJSON2Request("ack", APICounter(), params)
@@ -110,9 +125,10 @@ func FactoidACK(txID, fullTransaction string) (*FactoidTxStatus, error) {
 	return eb, nil
 }
 
-// EntryRevealACK will take the entryhash and search for the entry and the commit
-func EntryRevealACK(entryhash, fullTransaction, chainiID string) (*EntryStatus, error) {
-	params := ackRequest{Hash: entryhash, ChainID: chainiID, FullTransaction: fullTransaction}
+// EntryRevealACK makes an "ack" RPC request using the entryhash to search for
+// the entry or chain reveal.
+func EntryRevealACK(entryhash, fullTransaction, chainID string) (*EntryStatus, error) {
+	params := ackRequest{Hash: entryhash, ChainID: chainID, FullTransaction: fullTransaction}
 	req := NewJSON2Request("ack", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
@@ -131,8 +147,8 @@ func EntryRevealACK(entryhash, fullTransaction, chainiID string) (*EntryStatus, 
 }
 
 // EntryACK is a deprecated call and SHOULD NOT BE USED.
-// Use either EntryCommitAck or EntryRevealAck depending on the
-// type of hash you are sending.
+// Use either EntryCommitAck or EntryRevealAck depending on the type of hash
+// you are sending.
 func EntryACK(entryhash, fullTransaction string) (*EntryStatus, error) {
 	return EntryRevealACK(entryhash, fullTransaction, "0000000000000000000000000000000000000000000000000000000000000000")
 }


### PR DESCRIPTION
So far this covers ack.go. Working on getting through the entire library... More commits to come.