### PR TITLE
Fd 670 Identity Walletd API

### DIFF
--- a/get.go
+++ b/get.go
@@ -324,6 +324,39 @@ func GetAllChainEntries(chainid string) ([]*Entry, error) {
 	return es, nil
 }
 
+func GetAllChainEntriesAtHeight(chainid string, height int64) ([]*Entry, error) {
+	es := make([]*Entry, 0)
+
+	head, err := GetChainHeadAndStatus(chainid)
+	if err != nil {
+		return es, err
+	}
+
+	if head.ChainHead == "" && head.ChainInProcessList {
+		return nil, fmt.Errorf("Chain not yet included in a Directory Block")
+	}
+
+	for ebhash := head.ChainHead; ebhash != ZeroHash; {
+		eb, err := GetEBlock(ebhash)
+		if err != nil {
+			return es, err
+		}
+		if eb.Header.DBHeight > height {
+			ebhash = eb.Header.PrevKeyMR
+			continue
+		}
+		s, err := GetAllEBlockEntries(ebhash)
+		if err != nil {
+			return es, err
+		}
+		es = append(s, es...)
+
+		ebhash = eb.Header.PrevKeyMR
+	}
+
+	return es, nil
+}
+
 func GetFirstEntry(chainid string) (*Entry, error) {
 	e := new(Entry)
 

--- a/identity.go
+++ b/identity.go
@@ -29,10 +29,10 @@ func GetIdentityChainID(name []string) string {
 	return hex.EncodeToString(hs.Sum(nil))
 }
 
-// CreateIdentityChain creates a new chain with name as the ExtIDs and a json object
-// describing the identity's keys in the Content field
-func CreateIdentityChain(name []string, keys []*IdentityKey, ec *ECAddress) (string, error) {
-	e := Entry{}
+// NewIdentityChain creates an returns a Chain struct for a new identity. Publish it to
+// blockchain using the usual factom.CommitChain(...) and factom.RevealChain(...) calls.
+func NewIdentityChain(name []string, keys []*IdentityKey) *Chain {
+	e := &Entry{}
 	for _, part := range name {
 		e.ExtIDs = append(e.ExtIDs, []byte(part))
 	}
@@ -44,17 +44,8 @@ func CreateIdentityChain(name []string, keys []*IdentityKey, ec *ECAddress) (str
 	keysMap := map[string][]string{"keys": publicKeys}
 	keysJSON, _ := json.Marshal(keysMap)
 	e.Content = []byte(keysJSON)
-	chain := NewChain(&e)
-
-	txID, err := CommitChain(chain, ec)
-	if err != nil {
-		return "", err
-	}
-	_, err = RevealChain(chain)
-	if err != nil {
-		return "", err
-	}
-	return txID, nil
+	c := NewChain(e)
+	return c
 }
 
 // GetKeysAtHeight returns the identity's public keys that were/are valid at the highest saved block height

--- a/identity.go
+++ b/identity.go
@@ -58,17 +58,17 @@ func CreateIdentityChain(name []string, keys []*IdentityKey, ec *ECAddress) (str
 }
 
 // GetKeysAtHeight returns the identity's public keys that were/are valid at the highest saved block height
-func GetKeysAtCurrentHeight(chainID string) ([]*IdentityKey, error) {
+func (i *Identity) GetKeysAtCurrentHeight() ([]*IdentityKey, error) {
 	heights, err := GetHeights()
 	if err != nil {
 		return nil, err
 	}
-	return GetKeysAtHeight(chainID, heights.DirectoryBlockHeight)
+	return i.GetKeysAtHeight(heights.DirectoryBlockHeight)
 }
 
 // GetKeysAtHeight returns the identity's public keys that were valid at the specified block height
-func GetKeysAtHeight(chainID string, height int64) ([]*IdentityKey, error) {
-	entries, err := GetAllChainEntriesAtHeight(chainID, height)
+func (i *Identity) GetKeysAtHeight(height int64) ([]*IdentityKey, error) {
+	entries, err := GetAllChainEntriesAtHeight(i.ChainID, height)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,10 @@ func IsValidAttribute(entryHash string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	validKeys, err := GetKeysAtHeight(signerChainID, dblock.Header.SequenceNumber)
+
+	signer := &Identity{}
+	signer.ChainID = signerChainID
+	validKeys, err := signer.GetKeysAtHeight(dblock.Header.SequenceNumber)
 	if err != nil {
 		return false, err
 	}
@@ -296,7 +299,10 @@ func IsValidEndorsement(entryHash string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	validKeys, err := GetKeysAtHeight(signerChainID, dblock.Header.SequenceNumber)
+
+	signer := &Identity{}
+	signer.ChainID = signerChainID
+	validKeys, err := signer.GetKeysAtHeight(dblock.Header.SequenceNumber)
 	if err != nil {
 		return false, err
 	}

--- a/identity.go
+++ b/identity.go
@@ -1,0 +1,426 @@
+package factom
+
+import (
+	"bytes"
+	"fmt"
+	"encoding/json"
+
+	ed "github.com/FactomProject/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"github.com/FactomProject/factomd/common/primitives/random"
+)
+
+type Identity struct {
+	ChainID string
+	Name []string
+	Keys []*IdentityKey
+}
+
+func GetIdentity(name []string) (*Identity, error) {
+	// Create the ChainID from a series of hashes of the Identity name
+	hs := sha256.New()
+	for _, part := range name {
+		h := sha256.Sum256([]byte(part))
+		hs.Write(h[:])
+	}
+	chainID := hex.EncodeToString(hs.Sum(nil))
+	i := Identity{}
+	i.ChainID = chainID
+	i.Name = name
+
+	if !ChainExists(chainID) {
+		return nil, fmt.Errorf("chain not found")
+	}
+
+	keys, err := GetKeysAtCurrentHeight(i.ChainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get identity keys: %v", err)
+	}
+	i.Keys = keys
+	return &i, nil
+}
+
+func CreateIdentityChain(name []string, keys []*IdentityKey, ec *ECAddress) (string, error) {
+	e := Entry {}
+	for _, part := range name {
+		e.ExtIDs = append(e.ExtIDs, []byte(part))
+	}
+
+	var publicKeys []string
+	for _, key := range keys {
+		publicKeys = append(publicKeys, key.PubString())
+	}
+	keysMap := map[string][]string{"keys": publicKeys}
+	keysJSON, _ := json.Marshal(keysMap)
+	e.Content = []byte(keysJSON)
+	chain := NewChain(&e)
+
+	txID, err := CommitChain(chain, ec)
+	if err != nil {
+		return "", err
+	}
+	_, err = RevealChain(chain)
+	if err != nil {
+		return "", err
+	}
+	return txID, nil
+}
+
+// GetKeysAtHeight returns the identity's public keys that were/are valid at the highest saved block height
+func GetKeysAtCurrentHeight(chainID string) ([]*IdentityKey, error) {
+	heights, err := GetHeights()
+	if err != nil {
+		return nil, err
+	}
+	return GetKeysAtHeight(chainID, heights.DirectoryBlockHeight)
+}
+
+// GetKeysAtHeight returns the identity's public keys that were valid at the specified block height
+func GetKeysAtHeight(chainID string, height int64) ([]*IdentityKey, error) {
+	entries, err := GetAllChainEntriesAtHeight(chainID, height)
+	if err != nil {
+		return nil, err
+	}
+
+	var initialKeys map[string][]string
+	initialKeysJSON := entries[0].Content
+	err = json.Unmarshal(initialKeysJSON, &initialKeys)
+	if err != nil {
+		fmt.Println("Failed to unmarshal json from initial key declaration")
+		return nil, err
+	}
+
+	var validKeys []*IdentityKey
+	for _, pubString := range initialKeys["keys"] {
+		pub, err := hex.DecodeString(pubString)
+		if err != nil || len(pub) != 32 {
+			return nil, fmt.Errorf("invalid Identity public key string in first entry")
+		}
+		k := NewIdentityKey()
+		copy(k.Pub[:], pub)
+		validKeys = append(validKeys, k)
+	}
+
+	for _, e := range entries {
+		if len(e.ExtIDs) < 4 || bytes.Compare(e.ExtIDs[0], []byte("ReplaceKey")) != 0 {
+			continue
+		}
+		if len(e.ExtIDs[1]) != 32 || len(e.ExtIDs[2]) != 32 || len(e.ExtIDs[3]) != 64 {
+			continue
+		}
+		var oldKey [32]byte
+		var newKey [32]byte
+		var signature [64]byte
+		copy(oldKey[:], e.ExtIDs[1])
+		copy(newKey[:], e.ExtIDs[2])
+		copy(signature[:], e.ExtIDs[3])
+
+		levelToReplace := -1
+		for level, key := range validKeys {
+			if bytes.Compare(oldKey[:], key.PubBytes()) == 0 {
+				levelToReplace = level
+			}
+		}
+		if levelToReplace == -1 {
+			// oldkey not in the set of valid keys when this entry was published
+			continue
+		}
+
+		var message []byte
+		message = append(message, oldKey[:]...)
+		message = append(message, newKey[:]...)
+		for level, key := range validKeys {
+			if level > levelToReplace {
+				// low priority key trying to replace high priority key, disregard
+				break
+			}
+			if ed.Verify(key.Pub, message, &signature) {
+				validKeys[levelToReplace].Pub = &newKey
+				validKeys[levelToReplace].Sec = new([ed.PrivateKeySize]byte)
+				break
+			}
+		}
+	}
+
+	return validKeys, nil
+}
+
+func (i *Identity) ReplaceKey(oldKey *[32]byte, newKey *[32]byte, privateKey *[64]byte, ec *ECAddress) (string, error) {
+	//publicKey := ed.GetPublicKey(privateKey)
+	var message []byte
+	message = append(message, oldKey[:]...)
+	message = append(message, newKey[:]...)
+	signature := ed.Sign(privateKey, message)
+	e := Entry{}
+	e.ChainID = i.ChainID
+	e.ExtIDs = [][]byte{[]byte("ReplaceKey"), oldKey[:], newKey[:],  signature[:]}
+
+	txID, err := CommitEntry(&e, ec)
+	if err != nil {
+		return "", err
+	}
+	_, err = RevealEntry(&e)
+	if err != nil {
+		return "", err
+	}
+	return txID, nil
+}
+
+func WriteAttribute(receiverChainID string, destinationChainID string, attributesJSON string, privateKey *[64]byte, signerChainID string, ec *ECAddress) (string, []byte, error) {
+	message := []byte(receiverChainID + destinationChainID + attributesJSON)
+	signature := ed.Sign(privateKey, message)
+	publicKey := ed.GetPublicKey(privateKey)
+
+	e := Entry{}
+	e.ChainID = destinationChainID
+	e.ExtIDs = [][]byte{[]byte("IdentityAttribute"), []byte(receiverChainID), signature[:], publicKey[:], []byte(signerChainID)}
+	e.Content = []byte(attributesJSON)
+
+	txID, err := CommitEntry(&e, ec)
+	if err != nil {
+		return "", nil, err
+	}
+	_, err = RevealEntry(&e)
+	if err != nil {
+		return "", nil, err
+	}
+	return txID, e.Hash(), nil
+}
+
+// EndorseIdentityAttribute signs a message using the provided private key saying that the signing identity acknowledges/agrees with
+// the attribute entry located at entryHash
+func EndorseIdentityAttribute(destinationChainID string, attributeEntryHash string, privateKey *[64]byte, signerChainID string, ec *ECAddress) (string, []byte, error) {
+	message := []byte(destinationChainID + attributeEntryHash)
+	signature := ed.Sign(privateKey, message)
+	publicKey := ed.GetPublicKey(privateKey)
+
+	e := Entry{}
+	e.ChainID = destinationChainID
+	e.ExtIDs = [][]byte{[]byte("IdentityAttributeEndorsement"), signature[:], publicKey[:], []byte(signerChainID)}
+	e.Content = []byte(attributeEntryHash)
+
+	txID, err := CommitEntry(&e, ec)
+	if err != nil {
+		return "", nil, err
+	}
+	_, err = RevealEntry(&e)
+	if err != nil {
+		return "", nil, err
+	}
+	return txID, e.Hash(), nil
+}
+
+// IsValidAttribute returns true if the EntryHash points to a correctly formatted attribute entry with a signature
+// that was valid for its signer's identity at the time the attribute was published
+func IsValidAttribute(entryHash string) (bool, error) {
+	e, err := GetEntry(entryHash)
+	if err != nil {
+		return false, err
+	}
+
+	// Check ExtIDs for valid formatting, then process them
+	if len(e.ExtIDs) < 5 || bytes.Compare(e.ExtIDs[0], []byte("IdentityAttribute")) != 0 {
+		return false, nil
+	}
+	if len(e.ExtIDs[1]) != 64 || len(e.ExtIDs[2]) != 64 || len(e.ExtIDs[3]) != 32 || len(e.ExtIDs[4]) != 64 {
+		return false, nil
+	}
+	receiverChainID := e.ExtIDs[1]
+	var signature [64]byte
+	copy(signature[:], e.ExtIDs[2])
+	var pubKey [32]byte
+	copy(pubKey[:], e.ExtIDs[3])
+	signerChainID := string(e.ExtIDs[4])
+
+	// Message that was signed = ReceiverChainID + DestinationChainID + AttributesJSON
+	message := receiverChainID
+	message = append(message, []byte(e.ChainID)...)
+	message = append(message, e.Content...)
+	if !ed.Verify(&pubKey, message, &signature) {
+		return false, nil
+	}
+
+	// Check that public key was valid for the signer at the time of the attribute being published
+	receipt, err := GetReceipt(entryHash)
+	if err != nil {
+		return false, err
+	}
+	dblock, err := GetDBlock(receipt.DirectoryBlockKeyMR)
+	if err != nil {
+		return false, err
+	}
+	validKeys, err := GetKeysAtHeight(signerChainID, dblock.Header.SequenceNumber)
+	if err != nil {
+		return false, err
+	}
+	for _, key := range validKeys {
+		if bytes.Compare(pubKey[:], key.Pub[:]) == 0 {
+			// Found provided key to be valid at time of publishing attribute
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// IsValidEndorsement returns true if the EntryHash points to a correctly formatted endorsement entry with a signature
+// that was valid for its signer's identity at the time the attribute was published
+func IsValidEndorsement(entryHash string) (bool, error) {
+	e, err := GetEntry(entryHash)
+	if err != nil {
+		return false, err
+	}
+
+	// Check ExtIDs for valid formatting, then process them
+	if len(e.ExtIDs) < 4 || bytes.Compare(e.ExtIDs[0], []byte("IdentityAttributeEndorsement")) != 0 {
+		return false, nil
+	}
+	if len(e.ExtIDs[1]) != 64 || len(e.ExtIDs[2]) != 32 || len(e.ExtIDs[3]) != 64 {
+		return false, nil
+	}
+	var signature [64]byte
+	copy(signature[:], e.ExtIDs[1])
+	var pubKey [32]byte
+	copy(pubKey[:], e.ExtIDs[2])
+	signerChainID := string(e.ExtIDs[3])
+
+	// Message that was signed = DestinationChainID + AttributeEntryHash
+	message := []byte(e.ChainID)
+	message = append(message, e.Content...)
+	if !ed.Verify(&pubKey, message, &signature) {
+		return false, nil
+	}
+
+	// Check that public key was valid for the signer at the time of the attribute being published
+	receipt, err := GetReceipt(entryHash)
+	if err != nil {
+		return false, err
+	}
+	dblock, err := GetDBlock(receipt.DirectoryBlockKeyMR)
+	if err != nil {
+		return false, err
+	}
+	validKeys, err := GetKeysAtHeight(signerChainID, dblock.Header.SequenceNumber)
+	if err != nil {
+		return false, err
+	}
+	for _, key := range validKeys {
+		if bytes.Compare(pubKey[:], key.Pub[:]) == 0 {
+			// Found provided key to be valid at time of publishing attribute
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type IdentityKey struct {
+	Pub *[ed.PublicKeySize]byte
+	Sec *[ed.PrivateKeySize]byte
+}
+
+func GenerateRandomIdentityKey() *IdentityKey {
+	randomSecret := random.RandByteSliceOfLen(32)
+
+	key := NewIdentityKey()
+	copy(key.Sec[:32], randomSecret[:])
+	key.Pub = ed.GetPublicKey(key.Sec)
+	return key
+}
+
+func NewIdentityKey() *IdentityKey {
+	k := new(IdentityKey)
+	k.Pub = new([ed.PublicKeySize]byte)
+	k.Sec = new([ed.PrivateKeySize]byte)
+	return k
+}
+
+func (k *IdentityKey) UnmarshalBinary(data []byte) error {
+	_, err := k.UnmarshalBinaryData(data)
+	return err
+}
+
+func (k *IdentityKey) UnmarshalBinaryData(data []byte) ([]byte, error) {
+	if len(data) < 32 {
+		return nil, fmt.Errorf("secret key portion must be 32 bytes")
+	}
+
+	if k.Sec == nil {
+		k.Sec = new([ed.PrivateKeySize]byte)
+	}
+
+	copy(k.Sec[:], data[:32])
+	k.Pub = ed.GetPublicKey(k.Sec)
+
+	return data[32:], nil
+}
+
+func (k *IdentityKey) MarshalBinary() ([]byte, error) {
+	return k.SecBytes()[:32], nil
+}
+
+// GetIdentityKey takes a private key string and returns an IdentityKey.
+func GetIdentityKey(s string) (*IdentityKey, error) {
+	sec, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode identity private key string")
+	}
+	if len(sec) != 32 {
+		return nil, fmt.Errorf("incorrect length for identity private key string")
+	}
+
+	return MakeIdentityKey(sec)
+}
+
+func MakeIdentityKey(sec []byte) (*IdentityKey, error) {
+	if len(sec) != 32 {
+		return nil, fmt.Errorf("secret key portion must be 32 bytes")
+	}
+
+	k := NewIdentityKey()
+
+	err := k.UnmarshalBinary(sec)
+	if err != nil {
+		return nil, err
+	}
+
+	return k, nil
+}
+
+// PubBytes returns the []byte representation of the public key
+func (k *IdentityKey) PubBytes() []byte {
+	return k.Pub[:]
+}
+
+// PubFixed returns the fixed size public key
+func (k *IdentityKey) PubFixed() *[ed.PublicKeySize]byte {
+	return k.Pub
+}
+
+// PubString returns the string encoding of the public key
+func (k *IdentityKey) PubString() string {
+	return hex.EncodeToString(k.PubBytes())
+}
+
+// SecBytes returns the []byte representation of the secret key
+func (k *IdentityKey) SecBytes() []byte {
+	return k.Sec[:]
+}
+
+// SecFixed returns the fixed size secret key
+func (k *IdentityKey) SecFixed() *[ed.PrivateKeySize]byte {
+	return k.Sec
+}
+
+// SecString returns the string encoding of the secret key
+func (k *IdentityKey) SecString() string {
+	return hex.EncodeToString(k.SecBytes()[:32])
+}
+
+// Sign the message with the Identity private key
+func (k *IdentityKey) Sign(msg []byte) *[ed.SignatureSize]byte {
+	return ed.Sign(k.SecFixed(), msg)
+}
+
+func (k *IdentityKey) String() string {
+	return k.PubString()
+}

--- a/identityKeys.go
+++ b/identityKeys.go
@@ -6,21 +6,11 @@ import (
 	"encoding/base64"
 
 	ed "github.com/FactomProject/ed25519"
-	"github.com/FactomProject/factomd/common/primitives/random"
 )
 
 type IdentityKey struct {
 	Pub *[ed.PublicKeySize]byte
 	Sec *[ed.PrivateKeySize]byte
-}
-
-func GenerateRandomIdentityKey() *IdentityKey {
-	randomSecret := random.RandByteSliceOfLen(32)
-
-	key := NewIdentityKey()
-	copy(key.Sec[:32], randomSecret[:])
-	key.Pub = ed.GetPublicKey(key.Sec)
-	return key
 }
 
 func NewIdentityKey() *IdentityKey {

--- a/identityKeys.go
+++ b/identityKeys.go
@@ -36,8 +36,8 @@ func IdentityKeyStringType(s string) identityKeyStringType {
 	}
 
 	// verify the address checksum
-	body := p[:BodyLength]
-	check := p[AddressLength-ChecksumLength:]
+	body := p[:IDKeyBodyLength]
+	check := p[IDKeyLength-ChecksumLength:]
 	if !bytes.Equal(shad(body)[:ChecksumLength], check) {
 		return InvalidIdentityKey
 	}

--- a/identityKeys.go
+++ b/identityKeys.go
@@ -1,0 +1,122 @@
+package factom
+
+import (
+	"fmt"
+
+	"encoding/base64"
+
+	ed "github.com/FactomProject/ed25519"
+	"github.com/FactomProject/factomd/common/primitives/random"
+)
+
+type IdentityKey struct {
+	Pub *[ed.PublicKeySize]byte
+	Sec *[ed.PrivateKeySize]byte
+}
+
+func GenerateRandomIdentityKey() *IdentityKey {
+	randomSecret := random.RandByteSliceOfLen(32)
+
+	key := NewIdentityKey()
+	copy(key.Sec[:32], randomSecret[:])
+	key.Pub = ed.GetPublicKey(key.Sec)
+	return key
+}
+
+func NewIdentityKey() *IdentityKey {
+	k := new(IdentityKey)
+	k.Pub = new([ed.PublicKeySize]byte)
+	k.Sec = new([ed.PrivateKeySize]byte)
+	return k
+}
+
+func (k *IdentityKey) UnmarshalBinary(data []byte) error {
+	_, err := k.UnmarshalBinaryData(data)
+	return err
+}
+
+func (k *IdentityKey) UnmarshalBinaryData(data []byte) ([]byte, error) {
+	if len(data) < 32 {
+		return nil, fmt.Errorf("secret key portion must be 32 bytes")
+	}
+
+	if k.Sec == nil {
+		k.Sec = new([ed.PrivateKeySize]byte)
+	}
+
+	copy(k.Sec[:], data[:32])
+	k.Pub = ed.GetPublicKey(k.Sec)
+
+	return data[32:], nil
+}
+
+func (k *IdentityKey) MarshalBinary() ([]byte, error) {
+	return k.SecBytes()[:32], nil
+}
+
+// GetIdentityKey takes a private key string and returns an IdentityKey.
+func GetIdentityKey(s string) (*IdentityKey, error) {
+	sec, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode identity private key string")
+	}
+	if len(sec) != 32 {
+		return nil, fmt.Errorf("incorrect length for identity private key string")
+	}
+
+	return MakeIdentityKey(sec)
+}
+
+func MakeIdentityKey(sec []byte) (*IdentityKey, error) {
+	if len(sec) != 32 {
+		return nil, fmt.Errorf("secret key portion must be 32 bytes")
+	}
+
+	k := NewIdentityKey()
+
+	err := k.UnmarshalBinary(sec)
+	if err != nil {
+		return nil, err
+	}
+
+	return k, nil
+}
+
+// PubBytes returns the []byte representation of the public key
+func (k *IdentityKey) PubBytes() []byte {
+	return k.Pub[:]
+}
+
+// PubFixed returns the fixed size public key
+func (k *IdentityKey) PubFixed() *[ed.PublicKeySize]byte {
+	return k.Pub
+}
+
+// PubString returns the string encoding of the public key
+func (k *IdentityKey) PubString() string {
+	return base64.StdEncoding.EncodeToString(k.PubBytes())
+}
+
+// SecBytes returns the []byte representation of the secret key
+func (k *IdentityKey) SecBytes() []byte {
+	return k.Sec[:]
+}
+
+// SecFixed returns the fixed size secret key
+func (k *IdentityKey) SecFixed() *[ed.PrivateKeySize]byte {
+	return k.Sec
+}
+
+// SecString returns the string encoding of the secret key
+func (k *IdentityKey) SecString() string {
+	return base64.StdEncoding.EncodeToString(k.SecBytes()[:32])
+}
+
+// Sign the message with the Identity private key
+func (k *IdentityKey) Sign(msg []byte) *[ed.SignatureSize]byte {
+	return ed.Sign(k.SecFixed(), msg)
+}
+
+func (k *IdentityKey) String() string {
+	return k.PubString()
+}

--- a/identityKeys_test.go
+++ b/identityKeys_test.go
@@ -1,0 +1,75 @@
+package factom
+
+import (
+	"crypto/rand"
+	"testing"
+
+	ed "github.com/FactomProject/ed25519"
+	"bytes"
+)
+
+func TestMarshalIdendityKey(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		sec := make([]byte, 32)
+		_, err := rand.Read(sec)
+		if err != nil {
+			t.Error(err)
+		}
+
+		k1, err := MakeIdentityKey(sec)
+		if err != nil {
+			t.Error(err)
+		}
+
+		data1, err := k1.MarshalBinary()
+		if err != nil {
+			t.Error(err)
+		}
+
+		k2 := new(ECAddress)
+		data2, err := k2.UnmarshalBinaryData(data1)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(data2) != 0 {
+			t.Errorf("UnmarshalBinary left %d bytes remaining", len(data2))
+		}
+
+		if bytes.Compare(k1.SecBytes(), k2.SecBytes()) != 0 {
+			t.Errorf("Unmarshaled object has different secret.")
+		}
+
+		if bytes.Compare(k1.PubBytes(), k2.PubBytes()) != 0 {
+			t.Errorf("Unmarshaled object has different public.")
+		}
+	}
+}
+
+func TestNewIdentityKey(t *testing.T) {
+	key := NewIdentityKey()
+	pub := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	if key.PubString() != pub {
+		t.Errorf("new pubkey %s did not match %s", key.PubString(), pub)
+	}
+}
+
+func TestGetIdentityKey(t *testing.T) {
+	pub := "l7He0I0ziouQ3ffwRKfiDAI+82sZ51XQF9/W0Smhnjs="
+	sec := "aokN4TYcmHBxP4WTYCan0ymYQtqLoLeKbnNWivylD8g="
+
+	k, err := GetIdentityKey(sec)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if k.PubString() != pub {
+		t.Errorf("%s did not match %s", k.PubString(), pub)
+	}
+
+	msg := []byte("Hello Factom!")
+	sig := k.Sign(msg)
+	if !ed.Verify(k.PubFixed(), msg, sig) {
+		t.Errorf("Key signature did not match")
+	}
+}

--- a/identityKeys_test.go
+++ b/identityKeys_test.go
@@ -6,6 +6,7 @@ import (
 
 	ed "github.com/FactomProject/ed25519"
 	"bytes"
+	"github.com/FactomProject/go-bip32"
 )
 
 func TestMarshalIdendityKey(t *testing.T) {
@@ -48,15 +49,15 @@ func TestMarshalIdendityKey(t *testing.T) {
 
 func TestNewIdentityKey(t *testing.T) {
 	key := NewIdentityKey()
-	pub := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	pub := "idpub1koTMq9h7FRCAdgZmDhjW85FBUsDJ8n1MBz94UaWf61JvLL1aa"
 	if key.PubString() != pub {
 		t.Errorf("new pubkey %s did not match %s", key.PubString(), pub)
 	}
 }
 
 func TestGetIdentityKey(t *testing.T) {
-	pub := "l7He0I0ziouQ3ffwRKfiDAI+82sZ51XQF9/W0Smhnjs="
-	sec := "aokN4TYcmHBxP4WTYCan0ymYQtqLoLeKbnNWivylD8g="
+	pub := "idpub1p4YkMzskVrtbK45nBHaikGda9w5SMvKvVsQtgVUfLK5Y8tByb"
+	sec := "idsec2wH72BNR9QZhTMGDbxwLWGrghZQexZvLTros2wCekkc62N9h7s"
 
 	k, err := GetIdentityKey(sec)
 	if err != nil {
@@ -71,5 +72,60 @@ func TestGetIdentityKey(t *testing.T) {
 	sig := k.Sign(msg)
 	if !ed.Verify(k.PubFixed(), msg, sig) {
 		t.Errorf("Key signature did not match")
+	}
+}
+
+func TestMakeBIP44IdentityKey(t *testing.T) {
+	m := "yellow yellow yellow yellow yellow yellow yellow yellow yellow yellow yellow yellow"
+	pub := "idpub1p4YkMzskVrtbK45nBHaikGda9w5SMvKvVsQtgVUfLK5Y8tByb"
+	sec := "idsec2wH72BNR9QZhTMGDbxwLWGrghZQexZvLTros2wCekkc62N9h7s"
+
+	id, err := MakeBIP44IdentityKey(m, bip32.FirstHardenedChild, 0, 0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if id.String() != pub {
+		t.Errorf("incorrect public key from 12 words: got %s expecting %s", id.String(), pub)
+	}
+	if id.SecString() != sec {
+		t.Errorf("incorrect secret key from 12 words: got %s expecting %s", id.SecString(), sec)
+	}
+}
+
+func TestIsValidIdentityKey(t *testing.T) {
+	pub := "idpub1p4YkMzskVrtbK45nBHaikGda9w5SMvKvVsQtgVUfLK5Y8tByb"
+	sec := "idsec2wH72BNR9QZhTMGDbxwLWGrghZQexZvLTros2wCekkc62N9h7s"
+	badEmpty := ""
+	badLen := "idpub1p4YkMzskVrtbK45nBHaikGda9w5SMvKvVsQtgVUfLK5Y8tBybd"
+	badPrePub := "idpXb1p4YkMzskVrtbK45nBHaikGda9w5SMvKvVsQtgVUfLK5Y8tByb"
+	badPreSec := "idsXc2wH72BNR9QZhTMGDbxwLWGrghZQexZvLTros2wCekkc62N9h7s"
+	badCheckPub := "idpub1p4YkMzskVrtbK45nBHaikGda9w5SMvKvVsQtgVUfLK5Y8tBby"
+	badCheckSec := "idsec2wH72BNR9QZhTMGDbxwLWGrghZQexZvLTros2wCekkc62N9hs7"
+
+	if !IsValidIdentityKey(pub) {
+		t.Errorf("%s was not considered valid", pub)
+	}
+	if !IsValidIdentityKey(sec) {
+		t.Errorf("%s was not considered valid", sec)
+	}
+
+	if IsValidIdentityKey(badEmpty) {
+		t.Errorf("%s was considered valid", badEmpty)
+	}
+	if IsValidIdentityKey(badLen) {
+		t.Errorf("%s was considered valid", badLen)
+	}
+	if IsValidIdentityKey(badPrePub) {
+		t.Errorf("%s was considered valid", badPrePub)
+	}
+	if IsValidIdentityKey(badPreSec) {
+		t.Errorf("%s was considered valid", badPreSec)
+	}
+	if IsValidIdentityKey(badCheckPub) {
+		t.Errorf("%s was considered valid", badCheckPub)
+	}
+	if IsValidIdentityKey(badCheckSec) {
+		t.Errorf("%s was considered valid", badCheckSec)
 	}
 }

--- a/identity_test.go
+++ b/identity_test.go
@@ -1,0 +1,204 @@
+package factom
+
+import (
+	"testing"
+	"fmt"
+
+	ed "github.com/FactomProject/ed25519"
+	"encoding/json"
+)
+
+func TestGetIdentityChainID(t *testing.T) {
+	name := []string{"John", "Jacob", "Jingleheimer-Schmidt"}
+	observedChainID := GetIdentityChainID(name)
+	expectedChainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
+	if observedChainID != expectedChainID {
+		fmt.Println(observedChainID)
+		fmt.Println(expectedChainID)
+		t.Fail()
+	}
+}
+
+func TestNewIdentityChain(t *testing.T) {
+	name := []string{"John", "Jacob", "Jingleheimer-Schmidt"}
+	secretKeys := []string{
+		"OQt+S8561HclsbNHEgPF6gE8ElOl+cQ/I9bqolAW2WE=",
+		"IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=",
+		"oZU/23DMo3UK4HctBUGkpdUqgt0UqeCF6BhlNdmcPwY=",
+		"mwkcvN2a38Uv16FXlK01csWVjqXSvF7I6l+oBPmVCRQ=",
+	}
+	var keys []*IdentityKey
+	for _, v := range secretKeys {
+		k, _ := GetIdentityKey(v)
+		keys = append(keys, k)
+	}
+
+	newChain := NewIdentityChain(name, keys)
+	expectedChainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
+	t.Run("ChainID", func(t *testing.T) {
+		if newChain.ChainID != expectedChainID {
+			fmt.Println(newChain.ChainID)
+			fmt.Println(expectedChainID)
+			t.Fail()
+		}
+	})
+	t.Run("Keys accessible from Content", func(t *testing.T) {
+		var contentMap map[string]interface{}
+		content := newChain.FirstEntry.Content
+		err := json.Unmarshal(content, &contentMap)
+		if err != nil {
+			fmt.Println("Failed to unmarshal content")
+			t.Fail()
+		}
+		for i, v := range contentMap["keys"].([]interface{}) {
+			if keys[i].String() != v.(string) {
+				fmt.Println("Keys not properly formatted")
+				t.Fail()
+			}
+		}
+	})
+
+}
+
+func TestNewIdentityKeyReplacementEntry(t *testing.T) {
+	chainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
+	oldKey, _ := GetIdentityKey("mwkcvN2a38Uv16FXlK01csWVjqXSvF7I6l+oBPmVCRQ=")
+	newKey, _ := GetIdentityKey("TTqbfGahXE7MKJ1/kxv/HEGk0yAblehJ+tBs76goQAM=")
+	signerKey, _ := GetIdentityKey("IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=")
+
+	observedEntry := NewIdentityKeyReplacementEntry(chainID, oldKey, newKey, signerKey)
+
+	t.Run("ChainID", func(t *testing.T) {
+		if observedEntry.ChainID != chainID {
+			t.Fail()
+		}
+	})
+	t.Run("ExtIDs", func(t *testing.T) {
+		if len(observedEntry.ExtIDs) != 5 {
+			fmt.Println("len(ExtIDs) != 5")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[0]) != "ReplaceKey" {
+			fmt.Println("ReplaceKey is not first ExtID")
+			t.Fail()
+		}
+		if  string(observedEntry.ExtIDs[1]) != oldKey.String() ||
+			string(observedEntry.ExtIDs[2]) != newKey.String() ||
+			string(observedEntry.ExtIDs[4]) != signerKey.String() {
+			fmt.Println("Keys not formatted properly")
+			t.Fail()
+		}
+	})
+	t.Run("Signature", func(t *testing.T) {
+		var observedSignature [64]byte
+		copy(observedSignature[:], observedEntry.ExtIDs[3])
+		message := []byte(oldKey.String() + newKey.String())
+		if !ed.Verify(signerKey.Pub, message, &observedSignature) {
+			t.Fail()
+		}
+	})
+}
+
+func TestNewIdentityAttributeEntry(t *testing.T) {
+	receiverChainID := "5ef81cd345fd497a376ca5e5670ef10826d96e73c9f797b33ea46552a47834a3"
+	destinationChainID := "5a402200c5cf278e47905ce52d7d64529a0291829a7bd230072c5468be709069"
+	signerChainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
+	signerKey, _ := GetIdentityKey("IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=")
+	attributes := `[{"key":"email","value":"abc@def.ghi"}]`
+
+	observedEntry := NewIdentityAttributeEntry(receiverChainID, destinationChainID, attributes, signerKey, signerChainID)
+
+	t.Run("ChainID", func(t *testing.T) {
+		if observedEntry.ChainID != destinationChainID {
+			fmt.Println("Incorrect Destination ChainID")
+			t.Fail()
+		}
+	})
+	t.Run("ExtIDs", func(t *testing.T) {
+		if len(observedEntry.ExtIDs) != 5 {
+			fmt.Println("len(ExtIDs) != 5")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[0]) != "IdentityAttribute" {
+			fmt.Println("IdentityAttribute is not first ExtID")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[1]) != receiverChainID {
+			fmt.Println("Receiver ChainID is not ExtID[1]")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[4]) != signerChainID {
+			fmt.Println("Signer ChainID is not ExtID[4]")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[3]) != signerKey.String() {
+			fmt.Println("Signer key not properly formatted or is not ExtID[3]")
+			t.Fail()
+		}
+	})
+	t.Run("Attributes accessible from Content", func(t *testing.T) {
+		var attributes []IdentityAttribute
+		err := json.Unmarshal(observedEntry.Content, &attributes)
+		if err != nil {
+			fmt.Println("Failed to unmarshal content")
+		}
+		if attributes[0].Key != "email" {
+			fmt.Println("Incorrect key")
+			t.Fail()
+		}
+		if attributes[0].Value != "abc@def.ghi" {
+			fmt.Println("Incorrect value")
+			t.Fail()
+		}
+	})
+	t.Run("Signature", func(t *testing.T) {
+		var observedSignature [64]byte
+		copy(observedSignature[:], observedEntry.ExtIDs[2])
+		message := []byte(receiverChainID + destinationChainID + attributes)
+		if !ed.Verify(signerKey.Pub, message, &observedSignature) {
+			t.Fail()
+		}
+	})
+}
+
+func TestNewIdentityAttributeEndorsementEntry(t *testing.T) {
+	destinationChainID := "5a402200c5cf278e47905ce52d7d64529a0291829a7bd230072c5468be709069"
+	signerChainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
+	signerKey, _ := GetIdentityKey("IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=")
+	entryHash := "52385948ea3ab6fd67b07664ac6a30ae5f6afa94427a547c142517beaa9054d0"
+
+	observedEntry := NewIdentityAttributeEndorsementEntry(destinationChainID, entryHash, signerKey, signerChainID)
+
+	t.Run("ChainID", func(t *testing.T) {
+		if observedEntry.ChainID != destinationChainID {
+			fmt.Println("Incorrect Destination ChainID")
+			t.Fail()
+		}
+	})
+	t.Run("ExtIDs", func(t *testing.T) {
+		if len(observedEntry.ExtIDs) != 4 {
+			fmt.Println("len(ExtIDs) != 4")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[0]) != "IdentityAttributeEndorsement" {
+			fmt.Println("IdentityAttributeEndorsement is not first ExtID")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[3]) != signerChainID {
+			fmt.Println("Signer ChainID is not ExtID[3]")
+			t.Fail()
+		}
+		if string(observedEntry.ExtIDs[2]) != signerKey.String() {
+			fmt.Println("Signer key not properly formatted or is not ExtID[2]")
+			t.Fail()
+		}
+	})
+	t.Run("Signature", func(t *testing.T) {
+		var observedSignature [64]byte
+		copy(observedSignature[:], observedEntry.ExtIDs[1])
+		message := []byte(destinationChainID + entryHash)
+		if !ed.Verify(signerKey.Pub, message, &observedSignature) {
+			t.Fail()
+		}
+	})
+}

--- a/identity_test.go
+++ b/identity_test.go
@@ -13,9 +13,7 @@ func TestGetIdentityChainID(t *testing.T) {
 	observedChainID := GetIdentityChainID(name)
 	expectedChainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
 	if observedChainID != expectedChainID {
-		fmt.Println(observedChainID)
-		fmt.Println(expectedChainID)
-		t.Fail()
+		t.Errorf("got: %s but expected: %s", observedChainID, expectedChainID)
 	}
 }
 
@@ -47,13 +45,11 @@ func TestNewIdentityChain(t *testing.T) {
 		content := newChain.FirstEntry.Content
 		err := json.Unmarshal(content, &contentMap)
 		if err != nil {
-			fmt.Println("Failed to unmarshal content")
-			t.Fail()
+			t.Errorf("Failed to unmarshal content")
 		}
 		for i, v := range contentMap["keys"].([]interface{}) {
 			if keys[i].String() != v.(string) {
-				fmt.Println("Keys not properly formatted")
-				t.Fail()
+				t.Errorf("Keys not properly formatted")
 			}
 		}
 	})
@@ -75,18 +71,15 @@ func TestNewIdentityKeyReplacementEntry(t *testing.T) {
 	})
 	t.Run("ExtIDs", func(t *testing.T) {
 		if len(observedEntry.ExtIDs) != 5 {
-			fmt.Println("len(ExtIDs) != 5")
-			t.Fail()
+			t.Errorf("len(ExtIDs) != 5")
 		}
 		if string(observedEntry.ExtIDs[0]) != "ReplaceKey" {
-			fmt.Println("ReplaceKey is not first ExtID")
-			t.Fail()
+			t.Errorf("ReplaceKey is not first ExtID")
 		}
 		if  string(observedEntry.ExtIDs[1]) != oldKey.String() ||
 			string(observedEntry.ExtIDs[2]) != newKey.String() ||
 			string(observedEntry.ExtIDs[4]) != signerKey.String() {
-			fmt.Println("Keys not formatted properly")
-			t.Fail()
+			t.Errorf("Keys not formatted properly")
 		}
 	})
 	t.Run("Signature", func(t *testing.T) {
@@ -110,45 +103,37 @@ func TestNewIdentityAttributeEntry(t *testing.T) {
 
 	t.Run("ChainID", func(t *testing.T) {
 		if observedEntry.ChainID != destinationChainID {
-			fmt.Println("Incorrect Destination ChainID")
-			t.Fail()
+			t.Errorf("Incorrect Destination ChainID")
 		}
 	})
 	t.Run("ExtIDs", func(t *testing.T) {
 		if len(observedEntry.ExtIDs) != 5 {
-			fmt.Println("len(ExtIDs) != 5")
-			t.Fail()
+			t.Errorf("len(ExtIDs) != 5")
 		}
 		if string(observedEntry.ExtIDs[0]) != "IdentityAttribute" {
-			fmt.Println("IdentityAttribute is not first ExtID")
-			t.Fail()
+			t.Errorf("IdentityAttribute is not first ExtID")
 		}
 		if string(observedEntry.ExtIDs[1]) != receiverChainID {
-			fmt.Println("Receiver ChainID is not ExtID[1]")
-			t.Fail()
+			t.Errorf("Receiver ChainID is not ExtID[1]")
 		}
 		if string(observedEntry.ExtIDs[4]) != signerChainID {
-			fmt.Println("Signer ChainID is not ExtID[4]")
-			t.Fail()
+			t.Errorf("Signer ChainID is not ExtID[4]")
 		}
 		if string(observedEntry.ExtIDs[3]) != signerKey.String() {
-			fmt.Println("Signer key not properly formatted or is not ExtID[3]")
-			t.Fail()
+			t.Errorf("Signer key not properly formatted or is not ExtID[3]")
 		}
 	})
 	t.Run("Attributes accessible from Content", func(t *testing.T) {
 		var attributes []IdentityAttribute
 		err := json.Unmarshal(observedEntry.Content, &attributes)
 		if err != nil {
-			fmt.Println("Failed to unmarshal content")
+			t.Errorf("Failed to unmarshal content: %v", err)
 		}
 		if attributes[0].Key != "email" {
-			fmt.Println("Incorrect key")
-			t.Fail()
+			t.Errorf("Incorrect key")
 		}
 		if attributes[0].Value != "abc@def.ghi" {
-			fmt.Println("Incorrect value")
-			t.Fail()
+			t.Errorf("Incorrect value")
 		}
 	})
 	t.Run("Signature", func(t *testing.T) {
@@ -171,26 +156,21 @@ func TestNewIdentityAttributeEndorsementEntry(t *testing.T) {
 
 	t.Run("ChainID", func(t *testing.T) {
 		if observedEntry.ChainID != destinationChainID {
-			fmt.Println("Incorrect Destination ChainID")
-			t.Fail()
+			t.Errorf("Incorrect Destination ChainID")
 		}
 	})
 	t.Run("ExtIDs", func(t *testing.T) {
 		if len(observedEntry.ExtIDs) != 4 {
-			fmt.Println("len(ExtIDs) != 4")
-			t.Fail()
+			t.Errorf("len(ExtIDs) != 4")
 		}
 		if string(observedEntry.ExtIDs[0]) != "IdentityAttributeEndorsement" {
-			fmt.Println("IdentityAttributeEndorsement is not first ExtID")
-			t.Fail()
+			t.Errorf("IdentityAttributeEndorsement is not first ExtID")
 		}
 		if string(observedEntry.ExtIDs[3]) != signerChainID {
-			fmt.Println("Signer ChainID is not ExtID[3]")
-			t.Fail()
+			t.Errorf("Signer ChainID is not ExtID[3]")
 		}
 		if string(observedEntry.ExtIDs[2]) != signerKey.String() {
-			fmt.Println("Signer key not properly formatted or is not ExtID[2]")
-			t.Fail()
+			t.Errorf("Signer key not properly formatted or is not ExtID[2]")
 		}
 	})
 	t.Run("Signature", func(t *testing.T) {

--- a/identity_test.go
+++ b/identity_test.go
@@ -20,10 +20,10 @@ func TestGetIdentityChainID(t *testing.T) {
 func TestNewIdentityChain(t *testing.T) {
 	name := []string{"John", "Jacob", "Jingleheimer-Schmidt"}
 	secretKeys := []string{
-		"OQt+S8561HclsbNHEgPF6gE8ElOl+cQ/I9bqolAW2WE=",
-		"IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=",
-		"oZU/23DMo3UK4HctBUGkpdUqgt0UqeCF6BhlNdmcPwY=",
-		"mwkcvN2a38Uv16FXlK01csWVjqXSvF7I6l+oBPmVCRQ=",
+		"idsec2rChEHLz3SPQQx3syQtB11pHAmxyGjux5FntnS7xqTCieHxxTc",
+		"idsec1xuUyeCCrJhsojf2wLAZqRxPzPFR8Gidd9DRRid1yGy8ncAJG3",
+		"idsec2J3nNoqdiyboCBKDGauqN9Jb33dyFSqaJKZqTs6i5FmztsTn5f",
+		"idsec1jztZ7dypqtwtPPWxybZFNpvvpUh6g8oog6Mnk2gGCm1pNBTgE",
 	}
 	var keys []*IdentityKey
 	for _, v := range secretKeys {
@@ -58,9 +58,9 @@ func TestNewIdentityChain(t *testing.T) {
 
 func TestNewIdentityKeyReplacementEntry(t *testing.T) {
 	chainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
-	oldKey, _ := GetIdentityKey("mwkcvN2a38Uv16FXlK01csWVjqXSvF7I6l+oBPmVCRQ=")
-	newKey, _ := GetIdentityKey("TTqbfGahXE7MKJ1/kxv/HEGk0yAblehJ+tBs76goQAM=")
-	signerKey, _ := GetIdentityKey("IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=")
+	oldKey, _ := GetIdentityKey("idsec1jztZ7dypqtwtPPWxybZFNpvvpUh6g8oog6Mnk2gGCm1pNBTgE")
+	newKey, _ := GetIdentityKey("idsec2J3nNoqdiyboCBKDGauqN9Jb33dyFSqaJKZqTs6i5FmztsTn5f")
+	signerKey, _ := GetIdentityKey("idsec2wH72BNR9QZhTMGDbxwLWGrghZQexZvLTros2wCekkc62N9h7s")
 
 	observedEntry := NewIdentityKeyReplacementEntry(chainID, oldKey, newKey, signerKey)
 
@@ -96,7 +96,7 @@ func TestNewIdentityAttributeEntry(t *testing.T) {
 	receiverChainID := "5ef81cd345fd497a376ca5e5670ef10826d96e73c9f797b33ea46552a47834a3"
 	destinationChainID := "5a402200c5cf278e47905ce52d7d64529a0291829a7bd230072c5468be709069"
 	signerChainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
-	signerKey, _ := GetIdentityKey("IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=")
+	signerKey, _ := GetIdentityKey("idsec2J3nNoqdiyboCBKDGauqN9Jb33dyFSqaJKZqTs6i5FmztsTn5f")
 	attributes := `[{"key":"email","value":"abc@def.ghi"}]`
 
 	observedEntry := NewIdentityAttributeEntry(receiverChainID, destinationChainID, attributes, signerKey, signerChainID)
@@ -149,7 +149,7 @@ func TestNewIdentityAttributeEntry(t *testing.T) {
 func TestNewIdentityAttributeEndorsementEntry(t *testing.T) {
 	destinationChainID := "5a402200c5cf278e47905ce52d7d64529a0291829a7bd230072c5468be709069"
 	signerChainID := "e0cf1713b492e09e783d5d9f4fc6e2c71b5bdc9af4806a7937a5e935819717e9"
-	signerKey, _ := GetIdentityKey("IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0=")
+	signerKey, _ := GetIdentityKey("idsec2J3nNoqdiyboCBKDGauqN9Jb33dyFSqaJKZqTs6i5FmztsTn5f")
 	entryHash := "52385948ea3ab6fd67b07664ac6a30ae5f6afa94427a547c142517beaa9054d0"
 
 	observedEntry := NewIdentityAttributeEndorsementEntry(destinationChainID, entryHash, signerKey, signerChainID)

--- a/wallet.go
+++ b/wallet.go
@@ -85,6 +85,28 @@ func GenerateECAddress() (*ECAddress, error) {
 	return e, nil
 }
 
+func GenerateIdentityKey() (*IdentityKey, error) {
+	req := NewJSON2Request("generate-identity-key", APICounter(), nil)
+	resp, err := walletRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	k := new(addressResponse)
+	if err := json.Unmarshal(resp.JSONResult(), k); err != nil {
+		return nil, err
+	}
+	e, err := GetIdentityKey(k.Secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
 func ImportAddresses(addrs ...string) (
 	[]*FactoidAddress,
 	[]*ECAddress,

--- a/wallet.go
+++ b/wallet.go
@@ -285,8 +285,8 @@ func FetchFactoidAddress(fctpub string) (*FactoidAddress, error) {
 }
 
 func FetchIdentityKey(pub string) (*IdentityKey, error) {
-	params := new(addressRequest)
-	params.Address = pub
+	params := new(struct{Public string `json:"public"`})
+	params.Public = pub
 
 	req := NewJSON2Request("identity-key", APICounter(), params)
 	resp, err := walletRequest(req)

--- a/wallet.go
+++ b/wallet.go
@@ -262,6 +262,27 @@ func FetchFactoidAddress(fctpub string) (*FactoidAddress, error) {
 	return GetFactoidAddress(r.Secret)
 }
 
+func FetchIdentityKey(pub string) (*IdentityKey, error) {
+	params := new(addressRequest)
+	params.Address = pub
+
+	req := NewJSON2Request("identity-key", APICounter(), params)
+	resp, err := walletRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	r := new(addressResponse)
+	if err := json.Unmarshal(resp.JSONResult(), r); err != nil {
+		return nil, err
+	}
+
+	return GetIdentityKey(r.Secret)
+}
+
 func GetWalletHeight() (uint32, error) {
 	req := NewJSON2Request("get-height", APICounter(), nil)
 	resp, err := walletRequest(req)

--- a/wallet/database.go
+++ b/wallet/database.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/FactomProject/factom"
 	"github.com/FactomProject/factomd/common/factoid"
+	"github.com/FactomProject/factomd/common/primitives/random"
+	ed "github.com/FactomProject/ed25519"
 )
 
 // Wallet is a connection to a Factom Wallet Database
@@ -113,6 +115,22 @@ func (w *Wallet) GenerateECAddress() (*factom.ECAddress, error) {
 // The address can be reproduced in the future using the Wallet Seed.
 func (w *Wallet) GenerateFCTAddress() (*factom.FactoidAddress, error) {
 	return w.GetNextFCTAddress()
+}
+
+// GenerateIdentityKey creates and stores a new Identity Key in the Wallet.
+// TODO: allow the address to be reproduced in the future using the wallet seed
+func (w *Wallet) GenerateIdentityKey() (*factom.IdentityKey, error) {
+	randomSecret := random.RandByteSliceOfLen(32)
+
+	k := factom.NewIdentityKey()
+	copy(k.Sec[:32], randomSecret[:])
+	k.Pub = ed.GetPublicKey(k.Sec)
+
+	err := w.InsertIdentityKey(k)
+	if err != nil {
+		return nil, err
+	}
+	return k, nil
 }
 
 // GetAllAddresses retrieves all Entry Credit and Factoid Addresses from the

--- a/wallet/database_test.go
+++ b/wallet/database_test.go
@@ -246,3 +246,107 @@ func TestGetAllAddresses(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestPutIdentityKey(t *testing.T) {
+	sec := "aokN4TYcmHBxP4WTYCan0ymYQtqLoLeKbnNWivylD8g="
+
+	// create a new database
+	w, err := NewMapDBWallet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// write a new identity key to the db
+	k, err := factom.GetIdentityKey(sec)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := w.InsertIdentityKey(k); err != nil {
+		t.Error(err)
+	}
+
+	// Check that the key was written into the db
+	if _, err := w.GetIdentityKey(k.PubString()); err != nil {
+		t.Error(err)
+	}
+
+	// close and remove the testing db
+	if err := w.Close(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGenerateIdentityKey(t *testing.T) {
+	// create a new database
+	w, err := NewMapDBWallet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Generate a new identity key
+	k, err := w.GenerateIdentityKey()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that the key was written into the db
+	if _, err := w.GetIdentityKey(k.PubString()); err != nil {
+		t.Error(err)
+	}
+
+	// close and remove the testing db
+	if err := w.Close(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetAllIdentityKeys(t *testing.T) {
+	sec1 := "OQt+S8561HclsbNHEgPF6gE8ElOl+cQ/I9bqolAW2WE="
+	sec2 := "IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0="
+
+	correctLen := 2
+
+	// create a new database
+	w, err := NewMapDBWallet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// write a new identity keys to the db
+	k1, err := factom.GetIdentityKey(sec1)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := w.InsertIdentityKey(k1); err != nil {
+		t.Error(err)
+	}
+	k2, err := factom.GetIdentityKey(sec2)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := w.InsertIdentityKey(k2); err != nil {
+		t.Error(err)
+	}
+
+	// get all identity keys out of db
+	ks, err := w.GetAllIdentityKeys()
+	if err != nil {
+		t.Error(err)
+	} else if ks == nil {
+		t.Errorf("No Identity key was retrived")
+	}
+	// check that all the keys are there
+	if len(ks) != correctLen {
+		t.Errorf("Wrong number of identity keys were retrived: %v", ks)
+	}
+
+	// print the keys
+	for _, k := range ks {
+		t.Logf("%s %s", k, k.SecString())
+	}
+
+	// close and remove the testing db
+	if err := w.Close(); err != nil {
+		t.Error(err)
+	}
+}

--- a/wallet/database_test.go
+++ b/wallet/database_test.go
@@ -248,7 +248,7 @@ func TestGetAllAddresses(t *testing.T) {
 }
 
 func TestPutIdentityKey(t *testing.T) {
-	sec := "aokN4TYcmHBxP4WTYCan0ymYQtqLoLeKbnNWivylD8g="
+	sec := "idsec2J3nNoqdiyboCBKDGauqN9Jb33dyFSqaJKZqTs6i5FmztsTn5f"
 
 	// create a new database
 	w, err := NewMapDBWallet()
@@ -301,8 +301,8 @@ func TestGenerateIdentityKey(t *testing.T) {
 }
 
 func TestGetAllIdentityKeys(t *testing.T) {
-	sec1 := "OQt+S8561HclsbNHEgPF6gE8ElOl+cQ/I9bqolAW2WE="
-	sec2 := "IwlkC3xooRM2xq7N0m94InOYj9xcavQ36V3Ar3NUCW0="
+	sec1 := "idsec2J3nNoqdiyboCBKDGauqN9Jb33dyFSqaJKZqTs6i5FmztsTn5f"
+	sec2 := "idsec1xuUyeCCrJhsojf2wLAZqRxPzPFR8Gidd9DRRid1yGy8ncAJG3"
 
 	correctLen := 2
 

--- a/wallet/transaction.go
+++ b/wallet/transaction.go
@@ -18,12 +18,13 @@ import (
 )
 
 var (
-	ErrFeeTooLow     = errors.New("wallet: Insufficient Fee")
-	ErrNoSuchAddress = errors.New("wallet: No such address")
-	ErrTXExists      = errors.New("wallet: Transaction name already exists")
-	ErrTXNotExists   = errors.New("wallet: Transaction name was not found")
-	ErrTXNoInputs    = errors.New("wallet: Transaction has no inputs")
-	ErrTXInvalidName = errors.New("wallet: Transaction name is not valid")
+	ErrFeeTooLow         = errors.New("wallet: Insufficient Fee")
+	ErrNoSuchAddress     = errors.New("wallet: No such address")
+	ErrNoSuchIdentityKey = errors.New("wallet: No such identity key")
+	ErrTXExists          = errors.New("wallet: Transaction name already exists")
+	ErrTXNotExists       = errors.New("wallet: Transaction name was not found")
+	ErrTXNoInputs        = errors.New("wallet: Transaction has no inputs")
+	ErrTXInvalidName     = errors.New("wallet: Transaction name is not valid")
 )
 
 func (w *Wallet) NewTransaction(name string) error {

--- a/wallet/walletDBO.go
+++ b/wallet/walletDBO.go
@@ -26,6 +26,7 @@ var (
 	fcDBPrefix = []byte("Factoids")
 	ecDBPrefix = []byte("Entry Credits")
 	seedDBKey  = []byte("DB Seed")
+	identityDBPrefix = []byte("Identities")
 )
 
 type WalletDatabaseOverlay struct {
@@ -482,5 +483,93 @@ var _ interfaces.BinaryMarshallableAndCopyable = (*FA)(nil)
 func (t *FA) New() interfaces.BinaryMarshallableAndCopyable {
 	e := new(FA)
 	e.FactoidAddress = factom.NewFactoidAddress()
+	return e
+}
+
+
+func (db *WalletDatabaseOverlay) InsertIdentityKey(e *factom.IdentityKey) error {
+	if e == nil {
+		return nil
+	}
+
+	batch := []interfaces.Record{}
+	batch = append(batch, interfaces.Record{identityDBPrefix, []byte(e.String()), e})
+
+	return db.DBO.PutInBatch(batch)
+}
+
+func (db *WalletDatabaseOverlay) GetIdentityKey(str string) (*factom.IdentityKey, error) {
+	data, err := db.DBO.Get(identityDBPrefix, []byte(str), new(factom.IdentityKey))
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, ErrNoSuchIdentityKey
+	}
+	return data.(*factom.IdentityKey), nil
+}
+
+func (db *WalletDatabaseOverlay) GetAllIdentityKeys() ([]*factom.IdentityKey, error) {
+	list, err := db.DBO.FetchAllBlocksFromBucket(identityDBPrefix, new(ID))
+	if err != nil {
+		return nil, err
+	}
+	return toIdentityKeyList(list), nil
+}
+
+func toIdentityKeyList(source []interfaces.BinaryMarshallableAndCopyable) []*factom.IdentityKey {
+	answer := make([]*factom.IdentityKey, len(source))
+	for i, v := range source {
+		answer[i] = v.(*ID).IdentityKey
+	}
+	sort.Sort(byKeyName(answer))
+	return answer
+}
+
+func (db *WalletDatabaseOverlay) RemoveIdentityKey(pubString string) error {
+	if len(pubString) == 0 {
+		return nil
+	}
+
+	data, err := db.DBO.Get(identityDBPrefix, []byte(pubString), new(factom.IdentityKey))
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		return ErrNoSuchIdentityKey
+	}
+	err = db.DBO.Delete(identityDBPrefix, []byte(pubString))
+	if err == nil {
+		err := db.DBO.Delete(identityDBPrefix, []byte(pubString)) //delete twice to flush the db file
+		return err
+	} else {
+		return err
+	}
+
+	return nil
+}
+
+type byKeyName []*factom.IdentityKey
+
+func (f byKeyName) Len() int {
+	return len(f)
+}
+func (f byKeyName) Less(i, j int) bool {
+	a := strings.Compare(f[i].String(), f[j].String())
+	return a < 0
+}
+func (f byKeyName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+type ID struct {
+	*factom.IdentityKey
+}
+
+var _ interfaces.BinaryMarshallableAndCopyable = (*ID)(nil)
+
+func (t *ID) New() interfaces.BinaryMarshallableAndCopyable {
+	e := new(ID)
+	e.IdentityKey = factom.NewIdentityKey()
 	return e
 }

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -86,6 +86,13 @@ type identityKeysAtHeightRequest struct {
 	Height  int64  `json:"height"`
 }
 
+type identityChainRequest struct {
+	Name    []string `json:"name"`
+	PubKeys []string `json:"pubkeys"`
+	ECPub   string   `json:"ecpub"`
+	Force   bool     `json:"force"`
+}
+
 // responses
 
 type addressResponse struct {

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -150,8 +150,9 @@ type multiBalanceResponse struct {
 }
 
 type walletBackupResponse struct {
-	Seed      string             `json:"wallet-seed"`
-	Addresses []*addressResponse `json:"addresses"`
+	Seed         string                 `json:"wallet-seed"`
+	Addresses    []*addressResponse     `json:"addresses"`
+	IdentityKeys []*identityKeyResponse `json:"identity-keys"`
 }
 
 type multiTransactionResponse struct {

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -158,9 +158,9 @@ type multiIdentityKeyResponse struct {
 }
 
 type identityKeysAtHeightResponse struct {
-	ChainID string                 `json:"chainid"`
-	Height  int64                  `json:"height"`
-	Keys    []*identityKeyResponse `json:"keys"`
+	ChainID string   `json:"chainid"`
+	Height  int64    `json:"height"`
+	Keys    []string `json:"keys"`
 }
 
 // Helper structs

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -71,6 +71,17 @@ type chainRequest struct {
 	Force bool         `json:"force"`
 }
 
+type importIdentityKeysRequest struct {
+	Keys []struct {
+		Secret string `json:"secret"`
+	} `json:keys`
+}
+
+type identityKeysAtHeightRequest struct {
+	ChainID string `json:"chainid"`
+	Height  int64  `json:"height"`
+}
+
 // responses
 
 type addressResponse struct {
@@ -131,9 +142,8 @@ type identityKeyResponse struct {
 	Secret string `json:"secret,omitempty"`
 }
 
-type identityKeysAtHeightRequest struct {
-	ChainID string `json:"chainid"`
-	Height  int64  `json:"height"`
+type multiIdentityKeyResponse struct {
+	Keys []*identityKeyResponse `json:"keys"`
 }
 
 type identityKeysAtHeightResponse struct {

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -71,6 +71,10 @@ type chainRequest struct {
 	Force bool         `json:"force"`
 }
 
+type identityKeyRequest struct {
+	Public string `json:"public"`
+}
+
 type importIdentityKeysRequest struct {
 	Keys []struct {
 		Secret string `json:"secret"`

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -103,13 +103,13 @@ type identityKeyReplacementRequest struct {
 }
 
 type identityAttributeRequest struct {
-	ReceiverChainID    string      `json:"receiver-chainid"`
-	DestinationChainID string      `json:"destination-chainid"`
-	Attributes         []Attribute `json:"attributes"`
-	SignerKey          string      `json:"signerkey"`
-	SignerChainID      string      `json:"signer-chainid"`
-	ECPub              string      `json:"ecpub"`
-	Force              bool        `json:"force"`
+	ReceiverChainID    string                     `json:"receiver-chainid"`
+	DestinationChainID string                     `json:"destination-chainid"`
+	Attributes         []factom.IdentityAttribute `json:"attributes"`
+	SignerKey          string                     `json:"signerkey"`
+	SignerChainID      string                     `json:"signer-chainid"`
+	ECPub              string                     `json:"ecpub"`
+	Force              bool                       `json:"force"`
 }
 
 type identityAttributeEndorsementRequest struct {
@@ -197,9 +197,4 @@ type UnmarBody struct {
 	Jsonrpc string          `json:"jsonrps"`
 	Id      int             `json:"id"`
 	Result  balanceResponse `json:"result"`
-}
-
-type Attribute struct {
-	Key   interface{} `json:"key"`
-	Value interface{} `json:"value"`
 }

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -126,6 +126,22 @@ type heightResponse struct {
 	Height int64 `json:"height"`
 }
 
+type identityKeyResponse struct {
+	Public string `json:"public"`
+	Secret string `json:"secret,omitempty"`
+}
+
+type identityKeysAtHeightRequest struct {
+	ChainID string `json:"chainid"`
+	Height  int64  `json:"height"`
+}
+
+type identityKeysAtHeightResponse struct {
+	ChainID string                 `json:"chainid"`
+	Height  int64                  `json:"height"`
+	Keys    []*identityKeyResponse `json:"keys"`
+}
+
 // Helper structs
 
 type UnmarBody struct {

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -102,6 +102,25 @@ type identityKeyReplacementRequest struct {
 	Force     bool   `json:"force"`
 }
 
+type identityAttributeRequest struct {
+	ReceiverChainID    string      `json:"receiver-chainid"`
+	DestinationChainID string      `json:"destination-chainid"`
+	Attributes         []Attribute `json:"attributes"`
+	SignerKey          string      `json:"signerkey"`
+	SignerChainID      string      `json:"signer-chainid"`
+	ECPub              string      `json:"ecpub"`
+	Force              bool        `json:"force"`
+}
+
+type identityAttributeEndorsementRequest struct {
+	DestinationChainID string `json:"destination-chainid"`
+	EntryHash          string `json:"entry-hash"`
+	SignerKey          string `json:"signerkey"`
+	SignerChainID      string `json:"signer-chainid"`
+	ECPub              string `json:"ecpub"`
+	Force              bool   `json:"force"`
+}
+
 // responses
 
 type addressResponse struct {
@@ -178,4 +197,9 @@ type UnmarBody struct {
 	Jsonrpc string          `json:"jsonrps"`
 	Id      int             `json:"id"`
 	Result  balanceResponse `json:"result"`
+}
+
+type Attribute struct {
+	Key   interface{} `json:"key"`
+	Value interface{} `json:"value"`
 }

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -93,6 +93,15 @@ type identityChainRequest struct {
 	Force   bool     `json:"force"`
 }
 
+type identityKeyReplacementRequest struct {
+	ChainID   string `json:"chainid"`
+	OldKey    string `json:"oldkey"`
+	NewKey    string `json:"newkey"`
+	SignerKey string `json:"signerkey"`
+	ECPub     string `json:"ecpub"`
+	Force     bool   `json:"force"`
+}
+
 // responses
 
 type addressResponse struct {

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -260,6 +260,8 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleAllIdentityKeys(params)
 	case "import-identity-keys":
 		resp, jsonError = handleImportIdentityKeys(params)
+	case "remove-identity-key":
+		resp, jsonError = handleRemoveIdentityKey(params)
 	case "identity-keys-at-height":
 		resp, jsonError = handleIdentityKeysAtHeight(params)
 	default:
@@ -1088,6 +1090,23 @@ func handleImportIdentityKeys(params []byte) (interface{}, *factom.JSONError) {
 		keyResp.Secret = v.Secret
 		resp.Keys = append(resp.Keys, keyResp)
 	}
+	return resp, nil
+}
+
+func handleRemoveIdentityKey(params []byte) (interface{}, *factom.JSONError) {
+	req := new(identityKeyRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	err := fctWallet.WalletDatabaseOverlay.RemoveIdentityKey(req.Public)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	resp := new(simpleResponse)
+	resp.Success = true
+
 	return resp, nil
 }
 

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FactomProject/btcutil/base58"
 	"github.com/FactomProject/btcutil/certs"
 	"github.com/FactomProject/factom"
 	"github.com/FactomProject/factom/wallet"
@@ -1174,15 +1175,12 @@ func handleComposeIdentityChain(params []byte) (interface{}, *factom.JSONError) 
 
 	var keys []*factom.IdentityKey
 	for _, v := range req.PubKeys {
-		pub, err := base64.StdEncoding.DecodeString(v)
-		if err != nil {
-			return nil, newCustomInternalError(fmt.Sprintf("Failed to decode identity public key string: %s", v))
+		if factom.IdentityKeyStringType(v) != factom.IDPub {
+			return nil, newCustomInternalError(fmt.Sprintf("Invalid identity public key string: %s", v))
 		}
-		if len(pub) != 32 {
-			return nil, newCustomInternalError(fmt.Sprintf("Invalid length for identity public key string: %s", v))
-		}
+		b := base58.Decode(v)
 		k := factom.NewIdentityKey()
-		copy(k.Pub[:], pub[:32])
+		copy(k.Pub[:], b[factom.IDKeyPrefixLength:factom.IDKeyBodyLength])
 		keys = append(keys, k)
 	}
 	ecpub := req.ECPub

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -614,6 +614,17 @@ func handleWalletBackup(params []byte) (interface{}, *factom.JSONError) {
 		resp.Addresses = append(resp.Addresses, a)
 	}
 
+	idKeys, err := fctWallet.GetAllIdentityKeys()
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	for _, k := range idKeys {
+		keyResp := new(identityKeyResponse)
+		keyResp.Public = k.PubString()
+		keyResp.Secret = k.SecString()
+		resp.IdentityKeys = append(resp.IdentityKeys, keyResp)
+	}
+
 	return resp, nil
 }
 

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -1144,12 +1144,7 @@ func handleIdentityKeysAtHeight(params []byte) (interface{}, *factom.JSONError) 
 	resp.ChainID = req.ChainID
 	resp.Height = req.Height
 	for _, key := range keys {
-		keyResponse := new(identityKeyResponse)
-		keyResponse.Public = key.PubString()
-		if bytes.Compare(key.SecBytes(), factom.NewIdentityKey().SecBytes()) != 0 {
-			keyResponse.Secret = key.SecString()
-		}
-		resp.Keys = append(resp.Keys, keyResponse)
+		resp.Keys = append(resp.Keys, key.PubString())
 	}
 	return resp, nil
 }

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -260,6 +260,8 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleAllIdentityKeys(params)
 	case "import-identity-keys":
 		resp, jsonError = handleImportIdentityKeys(params)
+	case "generate-identity-key":
+		resp, jsonError = handleGenerateIdentityKey(params)
 	case "remove-identity-key":
 		resp, jsonError = handleRemoveIdentityKey(params)
 	case "identity-keys-at-height":
@@ -1090,6 +1092,17 @@ func handleImportIdentityKeys(params []byte) (interface{}, *factom.JSONError) {
 		keyResp.Secret = v.Secret
 		resp.Keys = append(resp.Keys, keyResp)
 	}
+	return resp, nil
+}
+
+func handleGenerateIdentityKey(params []byte) (interface{}, *factom.JSONError) {
+	k, err := fctWallet.GenerateIdentityKey()
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	resp := identityKeyResponse{}
+	resp.Public = k.PubString()
+	resp.Secret = k.SecString()
 	return resp, nil
 }
 

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -268,6 +268,8 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleIdentityKeysAtHeight(params)
 	case "compose-identity-chain":
 		resp, jsonError = handleComposeIdentityChain(params)
+	case "compose-identity-key-replacement":
+		resp, jsonError = handleComposeIdentityKeyReplacement(params)
 	default:
 		jsonError = newMethodNotFoundError()
 	}
@@ -1204,6 +1206,81 @@ func handleComposeIdentityChain(params []byte) (interface{}, *factom.JSONError) 
 	}
 
 	reveal, err := factom.ComposeChainReveal(c)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	resp := new(entryResponse)
+	resp.Commit = commit
+	resp.Reveal = reveal
+	return resp, nil
+}
+
+func handleComposeIdentityKeyReplacement(params []byte) (interface{}, *factom.JSONError) {
+	req := new(identityKeyReplacementRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	oldKey, err := fctWallet.GetIdentityKey(req.OldKey)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if oldKey == nil {
+		return nil, newCustomInternalError("Wallet: identity key not found")
+	}
+
+	newKey, err := fctWallet.GetIdentityKey(req.NewKey)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if newKey == nil {
+		return nil, newCustomInternalError("Wallet: identity key not found")
+	}
+
+	signerKey, err := fctWallet.GetIdentityKey(req.SignerKey)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if signerKey == nil {
+		return nil, newCustomInternalError("Wallet: identity key not found")
+	}
+
+	e := factom.NewIdentityKeyReplacementEntry(req.ChainID, oldKey, newKey, signerKey)
+	ecpub := req.ECPub
+	force := req.Force
+
+	ec, err := fctWallet.GetECAddress(ecpub)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if ec == nil {
+		return nil, newCustomInternalError("Wallet: address not found")
+	}
+	if !force {
+		// check ec address balance
+		balance, err := factom.GetECBalance(ecpub)
+		if err != nil {
+			return nil, newCustomInternalError(err.Error())
+		}
+
+		if cost, err := factom.EntryCost(e); err != nil {
+			newCustomInternalError(err.Error())
+		} else if balance < int64(cost) {
+			newCustomInternalError("Not enough Entry Credits")
+		}
+
+		if !factom.ChainExists(e.ChainID) {
+			return nil, newCustomInvalidParamsError("Chain " + e.ChainID + " was not found")
+		}
+	}
+
+	commit, err := factom.ComposeEntryCommit(e, ec)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	reveal, err := factom.ComposeEntryReveal(e)
 	if err != nil {
 		return nil, newCustomInternalError(err.Error())
 	}

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -254,6 +254,8 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleGetHeight(params)
 	case "wallet-balances":
 		resp, jsonError = handleWalletBalances(params)
+	case "identity-keys-at-height":
+		resp, jsonError = handleIdentityKeysAtHeight(params)
 	default:
 		jsonError = newMethodNotFoundError()
 	}
@@ -1021,6 +1023,33 @@ func handleGetHeight(params []byte) (interface{}, *factom.JSONError) {
 	}
 
 	resp.Height = int64(block.GetDBHeight())
+	return resp, nil
+}
+
+func handleIdentityKeysAtHeight(params []byte) (interface{}, *factom.JSONError) {
+	req := new(identityKeysAtHeightRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	identity := &factom.Identity{}
+	identity.ChainID = req.ChainID
+	keys, err := identity.GetKeysAtHeight(req.Height)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	resp := new(identityKeysAtHeightResponse)
+	resp.ChainID = req.ChainID
+	resp.Height = req.Height
+	for _, key := range keys {
+		keyResponse := new(identityKeyResponse)
+		keyResponse.Public = key.PubString()
+		if bytes.Compare(key.SecBytes(), factom.NewIdentityKey().SecBytes()) != 0 {
+			keyResponse.Secret = key.SecString()
+		}
+		resp.Keys = append(resp.Keys, keyResponse)
+	}
 	return resp, nil
 }
 

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -270,6 +270,10 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleComposeIdentityChain(params)
 	case "compose-identity-key-replacement":
 		resp, jsonError = handleComposeIdentityKeyReplacement(params)
+	case "compose-identity-attribute":
+		resp, jsonError = handleComposeIdentityAttribute(params)
+	case "compose-identity-attribute-endorsement":
+		resp, jsonError = handleComposeIdentityAttributeEndorsement(params)
 	default:
 		jsonError = newMethodNotFoundError()
 	}
@@ -1247,6 +1251,137 @@ func handleComposeIdentityKeyReplacement(params []byte) (interface{}, *factom.JS
 	}
 
 	e := factom.NewIdentityKeyReplacementEntry(req.ChainID, oldKey, newKey, signerKey)
+	ecpub := req.ECPub
+	force := req.Force
+
+	ec, err := fctWallet.GetECAddress(ecpub)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if ec == nil {
+		return nil, newCustomInternalError("Wallet: address not found")
+	}
+	if !force {
+		// check ec address balance
+		balance, err := factom.GetECBalance(ecpub)
+		if err != nil {
+			return nil, newCustomInternalError(err.Error())
+		}
+
+		if cost, err := factom.EntryCost(e); err != nil {
+			newCustomInternalError(err.Error())
+		} else if balance < int64(cost) {
+			newCustomInternalError("Not enough Entry Credits")
+		}
+
+		if !factom.ChainExists(e.ChainID) {
+			return nil, newCustomInvalidParamsError("Chain " + e.ChainID + " was not found")
+		}
+	}
+
+	commit, err := factom.ComposeEntryCommit(e, ec)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	reveal, err := factom.ComposeEntryReveal(e)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	resp := new(entryResponse)
+	resp.Commit = commit
+	resp.Reveal = reveal
+	return resp, nil
+}
+
+func handleComposeIdentityAttribute(params []byte) (interface{}, *factom.JSONError) {
+	req := new(identityAttributeRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	signerKey, err := fctWallet.GetIdentityKey(req.SignerKey)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if signerKey == nil {
+		return nil, newCustomInternalError("Wallet: identity key not found")
+	}
+
+	for _, attribute := range req.Attributes {
+		if attribute.Key == nil {
+			return nil, newCustomInternalError("Attribute key must not be nil")
+		}
+		if attribute.Value == nil {
+			return nil, newCustomInternalError("Attribute value must not be nil")
+		}
+	}
+	attributesJSON, err := json.Marshal(req.Attributes)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	e := factom.NewIdentityAttributeEntry(req.ReceiverChainID, req.DestinationChainID, string(attributesJSON), signerKey, req.SignerChainID)
+	ecpub := req.ECPub
+	force := req.Force
+
+	ec, err := fctWallet.GetECAddress(ecpub)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if ec == nil {
+		return nil, newCustomInternalError("Wallet: address not found")
+	}
+	if !force {
+		// check ec address balance
+		balance, err := factom.GetECBalance(ecpub)
+		if err != nil {
+			return nil, newCustomInternalError(err.Error())
+		}
+
+		if cost, err := factom.EntryCost(e); err != nil {
+			newCustomInternalError(err.Error())
+		} else if balance < int64(cost) {
+			newCustomInternalError("Not enough Entry Credits")
+		}
+
+		if !factom.ChainExists(e.ChainID) {
+			return nil, newCustomInvalidParamsError("Chain " + e.ChainID + " was not found")
+		}
+	}
+
+	commit, err := factom.ComposeEntryCommit(e, ec)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	reveal, err := factom.ComposeEntryReveal(e)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	resp := new(entryResponse)
+	resp.Commit = commit
+	resp.Reveal = reveal
+	return resp, nil
+}
+
+func handleComposeIdentityAttributeEndorsement(params []byte) (interface{}, *factom.JSONError) {
+	req := new(identityAttributeEndorsementRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	signerKey, err := fctWallet.GetIdentityKey(req.SignerKey)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if signerKey == nil {
+		return nil, newCustomInternalError("Wallet: identity key not found")
+	}
+
+	e := factom.NewIdentityAttributeEndorsementEntry(req.DestinationChainID, req.EntryHash, signerKey, req.SignerChainID)
 	ecpub := req.ECPub
 	force := req.Force
 

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -266,6 +266,8 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleRemoveIdentityKey(params)
 	case "identity-keys-at-height":
 		resp, jsonError = handleIdentityKeysAtHeight(params)
+	case "compose-identity-chain":
+		resp, jsonError = handleComposeIdentityChain(params)
 	default:
 		jsonError = newMethodNotFoundError()
 	}
@@ -1036,6 +1038,8 @@ func handleGetHeight(params []byte) (interface{}, *factom.JSONError) {
 	return resp, nil
 }
 
+// Identity handlers
+
 func handleIdentityKey(params []byte) (interface{}, *factom.JSONError) {
 	req := new(identityKeyRequest)
 	if err := json.Unmarshal(params, req); err != nil {
@@ -1147,6 +1151,71 @@ func handleIdentityKeysAtHeight(params []byte) (interface{}, *factom.JSONError) 
 		}
 		resp.Keys = append(resp.Keys, keyResponse)
 	}
+	return resp, nil
+}
+
+func handleComposeIdentityChain(params []byte) (interface{}, *factom.JSONError) {
+	req := new(identityChainRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	var keys []*factom.IdentityKey
+	for _, v := range req.PubKeys {
+		pub, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			return nil, newCustomInternalError(fmt.Sprintf("Failed to decode identity public key string: %s", v))
+		}
+		if len(pub) != 32 {
+			return nil, newCustomInternalError(fmt.Sprintf("Invalid length for identity public key string: %s", v))
+		}
+		k := factom.NewIdentityKey()
+		copy(k.Pub[:], pub[:32])
+		keys = append(keys, k)
+	}
+	ecpub := req.ECPub
+	force := req.Force
+	c := factom.NewIdentityChain(req.Name, keys)
+
+	ec, err := fctWallet.GetECAddress(ecpub)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if ec == nil {
+		return nil, newCustomInternalError("Wallet: address not found")
+	}
+
+	if !force {
+		// check ec address balance
+		balance, err := factom.GetECBalance(ecpub)
+		if err != nil {
+			return nil, newCustomInternalError(err.Error())
+		}
+
+		if cost, err := factom.EntryCost(c.FirstEntry); err != nil {
+			return nil, newCustomInternalError(err.Error())
+		} else if balance < int64(cost)+10 {
+			return nil, newCustomInternalError("Not enough Entry Credits")
+		}
+
+		if factom.ChainExists(c.ChainID) {
+			return nil, newCustomInvalidParamsError("Chain " + c.ChainID + " already exists")
+		}
+	}
+
+	commit, err := factom.ComposeChainCommit(c, ec)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	reveal, err := factom.ComposeChainReveal(c)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	resp := new(entryResponse)
+	resp.Commit = commit
+	resp.Reveal = reveal
 	return resp, nil
 }
 

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -254,6 +254,10 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleGetHeight(params)
 	case "wallet-balances":
 		resp, jsonError = handleWalletBalances(params)
+	case "identity-key":
+		resp, jsonError = handleIdentityKey(params)
+	case "all-identity-keys":
+		resp, jsonError = handleAllIdentityKeys(params)
 	case "import-identity-keys":
 		resp, jsonError = handleImportIdentityKeys(params)
 	case "identity-keys-at-height":
@@ -1025,6 +1029,42 @@ func handleGetHeight(params []byte) (interface{}, *factom.JSONError) {
 	}
 
 	resp.Height = int64(block.GetDBHeight())
+	return resp, nil
+}
+
+func handleIdentityKey(params []byte) (interface{}, *factom.JSONError) {
+	req := new(identityKeyRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	e, err := fctWallet.GetIdentityKey(req.Public)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	if e == nil {
+		return nil, newCustomInternalError("Wallet: identity key not found")
+	}
+	resp := new(identityKeyResponse)
+	resp.Public = e.PubString()
+	resp.Secret = e.SecString()
+	return resp, nil
+}
+
+func handleAllIdentityKeys(params []byte) (interface{}, *factom.JSONError) {
+	resp := new(multiIdentityKeyResponse)
+
+	keys, err := fctWallet.GetAllIdentityKeys()
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+	for _, v := range keys {
+		key := new(identityKeyResponse)
+		key.Public = v.PubString()
+		key.Secret = v.SecString()
+		resp.Keys = append(resp.Keys, key)
+	}
+
 	return resp, nil
 }
 

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -254,6 +254,8 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 		resp, jsonError = handleGetHeight(params)
 	case "wallet-balances":
 		resp, jsonError = handleWalletBalances(params)
+	case "import-identity-keys":
+		resp, jsonError = handleImportIdentityKeys(params)
 	case "identity-keys-at-height":
 		resp, jsonError = handleIdentityKeysAtHeight(params)
 	default:
@@ -1023,6 +1025,29 @@ func handleGetHeight(params []byte) (interface{}, *factom.JSONError) {
 	}
 
 	resp.Height = int64(block.GetDBHeight())
+	return resp, nil
+}
+
+func handleImportIdentityKeys(params []byte) (interface{}, *factom.JSONError) {
+	req := new(importIdentityKeysRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	resp := new(multiIdentityKeyResponse)
+	for _, v := range req.Keys {
+		key, err := factom.GetIdentityKey(v.Secret)
+		if err != nil {
+			return nil, newCustomInternalError(err.Error())
+		}
+		if err := fctWallet.InsertIdentityKey(key); err != nil {
+			return nil, newCustomInternalError(err.Error())
+		}
+		keyResp := new(identityKeyResponse)
+		keyResp.Public = key.PubString()
+		keyResp.Secret = v.Secret
+		resp.Keys = append(resp.Keys, keyResp)
+	}
 	return resp, nil
 }
 


### PR DESCRIPTION
This branch contains the changes necessary to add Identity support to both the go library and the factom-walletd wsapi. Wasn't entirely sure on the structuring and if Identity and Identity keys belonged in the factom or wallet package (will move them to wallet if people agree that is a better fit).

Documentation for identity chain/entry structures: https://docs.google.com/document/d/1NooBhYdRARwmfqMS0lrbFoXxgbB8cFrsWIl0d0kdhF8/edit?usp=sharing

Request structures:
```
# Generate a new key pair
'{"jsonrpc": "2.0", "id": 0, "method": "generate-identity-key"}'

# Import an identity private key
'{"jsonrpc": "2.0", "id": 0, "method": "import-identity-keys", "params":{"keys":[{"secret":"idsec..."},{"secret":"idsec..."},{"secret":"idsec..."}]}}'

# Fetch an identity key by its public key ("idpub...")
'{"jsonrpc": "2.0", "id": 0, "method": "identity-key", "params":{"public":"idpub..."}}'

# Get all identity key pairs in the wallet
'{"jsonrpc": "2.0", "id": 0, "method": "all-identity-keys"}'

# Remove a specific identity key pair that corresponds to the given public key
'{"jsonrpc": "2.0", "id": 0, "method": "remove-identity-key", "params":{"public":"idpub..."}}'

# Compose commit/reveal requests for a new identity
'{"jsonrpc": "2.0", "id": 0, "method":"compose-identity-chain", "params":{"name":["John","Jacob","Jingleheimer-Schmidt"]‌, "pubkeys":["idpub...","idpub...","idpub..."], "ecpub":""}}'

# Get valid public keys for an identity
'{"jsonrpc": "2.0", "id": 0, "method":"identity-keys-at-height", "params":{"chainid":"", "height":1600}}'

# Compose commit/reveal requests for identity key replacement
'{"jsonrpc": "2.0", "id": 0, "method": "compose-identity-key-replacement", "params":{"chainid":"", "oldkey":"idpub...", "newkey":"idpub...", "signerkey":"idpub...", "ecpub":""}}'

# Compose commit/reveal requests for an identity attribute
'{"jsonrpc": "2.0", "id": 0, "method": "compose-identity-attribute", "params":{"receiver-chainid":"", "destination-chainid":"", "attributes":[{"key":"email","value":"sam@abc.com"}], "signerkey":"idpub...", "signer-chainid":"", "ecpub":""}}'

# Compose commit/reveal requests for an identity attribute endorsement
'{"jsonrpc": "2.0", "id": 0, "method": "compose-identity-attribute-endorsement", "params":{"destination-chainid":"", "entry-hash":"", "signerkey":"idpub...", "signer-chainid":"", "ecpub":""}}'
```