### PR TITLE
FD-854 register slip44 for identity 

### DIFF
--- a/identityKeys.go
+++ b/identityKeys.go
@@ -151,7 +151,7 @@ func MakeBIP44IdentityKey(mnemonic string, account, chain, address uint32) (*Ide
 		return nil, err
 	}
 
-	child, err := bip44.NewKeyFromMnemonic(mnemonic, 0x88888888, account, chain, address)
+	child, err := bip44.NewKeyFromMnemonic(mnemonic, 0x80000119, account, chain, address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The factom identity was registered as a coin type, but the registered identity changed to 281 from 143165576   (from 0x88888888 to x80000119)



https://github.com/satoshilabs/slips/pull/558