### PR TITLE
API call to sign arbitrary data

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -9,13 +9,16 @@ type Signature struct {
 	Signature []byte `json:"signature"`
 }
 
-func SignData(addr string, data []byte) (*Signature, error) {
+// SignData lets you sign arbitrary data by the specified signer.
+// The signer can be either an FA address, EC address, or Identity.
+// Be aware that the data is transmitted to the wallet.
+func SignData(signer string, data []byte) (*Signature, error) {
 	params := &struct {
-		Address string `json:"address"`
-		Data    []byte `json:"data"`
+		Signer string `json:"signer"`
+		Data   []byte `json:"data"`
 	}{
-		Address: addr,
-		Data:    data,
+		Signer: signer,
+		Data:   data,
 	}
 
 	req := NewJSON2Request("sign-data", APICounter(), params)

--- a/sign.go
+++ b/sign.go
@@ -1,0 +1,36 @@
+package factom
+
+import (
+	"encoding/json"
+)
+
+type Signature struct {
+	PubKey    []byte `json:"pubkey"`
+	Signature []byte `json:"signature"`
+}
+
+func SignData(addr string, data []byte) (*Signature, error) {
+	params := &struct {
+		Address string `json:"address"`
+		Data    []byte `json:"data"`
+	}{
+		Address: addr,
+		Data:    data,
+	}
+
+	req := NewJSON2Request("sign-data", APICounter(), params)
+	resp, err := walletRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	sig := new(Signature)
+	if err := json.Unmarshal(resp.Result, sig); err != nil {
+		return nil, err
+	}
+	return sig, nil
+
+}

--- a/wallet/sign.go
+++ b/wallet/sign.go
@@ -1,0 +1,16 @@
+package wallet
+
+import (
+	"github.com/FactomProject/factomd/common/primitives"
+)
+
+// SignData signs arbitrary data
+func (w *Wallet) SignData(address string, data []byte) ([]byte, []byte, error) {
+	f, err := w.GetFCTAddress(address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sig := primitives.Sign(f.SecBytes(), data)
+	return f.PubBytes(), sig, nil
+}

--- a/wallet/sign.go
+++ b/wallet/sign.go
@@ -5,12 +5,24 @@ import (
 )
 
 // SignData signs arbitrary data
-func (w *Wallet) SignData(address string, data []byte) ([]byte, []byte, error) {
-	f, err := w.GetFCTAddress(address)
-	if err != nil {
-		return nil, nil, err
+func (w *Wallet) SignData(signer string, data []byte) ([]byte, []byte, error) {
+
+	var priv []byte
+	var pub []byte
+
+	if fa, err := w.GetFCTAddress(signer); err == nil {
+		priv = fa.SecBytes()
+		pub = fa.PubBytes()
+	} else if ec, err := w.GetECAddress(signer); err == nil {
+		priv = ec.SecBytes()
+		pub = ec.PubBytes()
+	} else if id, err := w.GetIdentityKey(signer); err == nil {
+		priv = id.SecBytes()
+		pub = id.PubBytes()
+	} else {
+		return nil, nil, ErrNoSuchAddress
 	}
 
-	sig := primitives.Sign(f.SecBytes(), data)
-	return f.PubBytes(), sig, nil
+	sig := primitives.Sign(priv, data)
+	return pub, sig, nil
 }

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -44,6 +44,11 @@ type transactionRequest struct {
 	Force bool   `json:"force"`
 }
 
+type signDataRequest struct {
+	Address string `json:"address"`
+	Data    []byte `json:"data"`
+}
+
 type transactionValueRequest struct {
 	Name    string `json:"tx-name"`
 	Address string `json:"address"`
@@ -200,6 +205,11 @@ type activeIdentityKeysResponse struct {
 	ChainID string   `json:"chainid"`
 	Height  int64    `json:"height"`
 	Keys    []string `json:"keys"`
+}
+
+type signDataResponse struct {
+	PubKey    []byte `json:"pubkey"`
+	Signature []byte `json:"signature"`
 }
 
 // Helper structs

--- a/wallet/wsapi/structs.go
+++ b/wallet/wsapi/structs.go
@@ -45,8 +45,8 @@ type transactionRequest struct {
 }
 
 type signDataRequest struct {
-	Address string `json:"address"`
-	Data    []byte `json:"data"`
+	Signer string `json:"signer"`
+	Data   []byte `json:"data"`
 }
 
 type transactionValueRequest struct {

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -265,6 +265,8 @@ func handleV2Request(j *factom.JSON2Request) (*factom.JSON2Response, *factom.JSO
 			resp, jsonError = handleSubFee(params)
 		case "sign-transaction":
 			resp, jsonError = handleSignTransaction(params)
+		case "sign-data":
+			resp, jsonError = handleSignData(params)
 		case "compose-transaction":
 			resp, jsonError = handleComposeTransaction(params)
 		case "remove-address":
@@ -950,6 +952,20 @@ func handleSignTransaction(params []byte) (interface{}, *factom.JSONError) {
 	resp.FeesRequired = feesRequired(tx)
 
 	return resp, nil
+}
+
+func handleSignData(params []byte) (interface{}, *factom.JSONError) {
+	req := new(signDataRequest)
+	if err := json.Unmarshal(params, req); err != nil {
+		return nil, newInvalidParamsError()
+	}
+
+	pub, sig, err := fctWallet.SignData(req.Address, req.Data)
+	if err != nil {
+		return nil, newCustomInternalError(err.Error())
+	}
+
+	return signDataResponse{PubKey: pub, Signature: sig}, nil
 }
 
 func handleComposeTransaction(params []byte) (interface{}, *factom.JSONError) {

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -960,7 +960,7 @@ func handleSignData(params []byte) (interface{}, *factom.JSONError) {
 		return nil, newInvalidParamsError()
 	}
 
-	pub, sig, err := fctWallet.SignData(req.Address, req.Data)
+	pub, sig, err := fctWallet.SignData(req.Signer, req.Data)
 	if err != nil {
 		return nil, newCustomInternalError(err.Error())
 	}


### PR DESCRIPTION
There is currently no way to sign arbitrary data without retrieving a private key over the network, which is fundamentally a bad idea. Currently both FAT and PegNet sign their custom transaction entries by querying the private key of an address over the api, then signing locally.

This would add a "sign-data" method to the wallet that takes an FA address and arbitrary byte data as parameters:
https://github.com/FactomProject/factom/blob/5c3c980549fecf24227a511191f7ad75c7ac488b/wallet/wsapi/structs.go#L47-L50

and returns a public key + signature pair:
https://github.com/FactomProject/factom/blob/5c3c980549fecf24227a511191f7ad75c7ac488b/wallet/wsapi/structs.go#L210-L213

The downside here is that you have to transfer the data to the wallet in order to sign it but with the advantage of never having to retrieve the private key over a potentially unsecure connection. If you need to sign a lot of data, you can still use the alternate method or just sign a hash of the data instead.

I think this would make the ecosystem a lot safer and the wallet a lot more useful for layer 2 applications.

The PR also includes a corresponding factom go client function to call this API endpoint:
https://github.com/FactomProject/factom/blob/5c3c980549fecf24227a511191f7ad75c7ac488b/sign.go#L7-L12