### PR TITLE
Whitelist feature for wallet

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -18,20 +18,21 @@ import (
 
 // RPCConfig is the configuration for the API handler
 type RPCConfig struct {
-	WalletTLSEnable    bool
-	WalletTLSKeyFile   string
-	WalletTLSCertFile  string
-	WalletRPCUser      string
-	WalletRPCPassword  string
-	WalletServer       string
-	WalletTimeout      time.Duration
-	WalletCORSDomains  string
-	FactomdTLSEnable   bool
-	FactomdTLSCertFile string
-	FactomdRPCUser     string
-	FactomdRPCPassword string
-	FactomdServer      string
-	FactomdTimeout     time.Duration
+	WalletTLSEnable       bool
+	WalletTLSKeyFile      string
+	WalletTLSCertFile     string
+	WalletRPCUser         string
+	WalletRPCPassword     string
+	WalletServer          string
+	WalletTimeout         time.Duration
+	WalletCORSDomains     string
+	FactomdTLSEnable      bool
+	FactomdTLSCertFile    string
+	FactomdRPCUser        string
+	FactomdRPCPassword    string
+	FactomdServer         string
+	FactomdTimeout        time.Duration
+	WalletWhiteListEnable bool
 }
 
 func EncodeJSON(data interface{}) ([]byte, error) {

--- a/wallet/wsapi/wsapi.go
+++ b/wallet/wsapi/wsapi.go
@@ -170,8 +170,18 @@ func checkWhitelistHeader(r *http.Request) error {
 	if !whitelistEnable {
 		return nil
 	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return errors.New("unable to determine ip address of " + r.RemoteAddr)
+	}
+
+	if host == "127.0.0.1" || host == "::1" {
+		return nil
+	}
+
 	for _, ip := range whitelist {
-		if ip == r.RemoteAddr {
+		if ip == host {
 			return nil
 		}
 	}


### PR DESCRIPTION
This implements a simple whitelist feature for wsapi. It's enabled by starting the webserver with `RPCConfig.WalletWhiteListEnable = true`. IPs to whitelist can be added with `wsapi.WhiteListIP(string)`.

Localhost (127.0.0.1, ::1) will always be able to connect. If a connection is attempted from a remote address not on the white list, the attempt is logged in the console and a 401 error is returned. 