### PR TITLE
Make raw data optional in API Requests

### DIFF
--- a/ablock.go
+++ b/ablock.go
@@ -5,7 +5,6 @@
 package factom
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -602,21 +601,21 @@ func (a *AdminAddAuthorityEfficiency) String() string {
 	return s
 }
 
-func getABlock(keymr string, noraw bool) (ablock *ABlock, raw []byte, err error) {
-	params := keyMRRequest{KeyMR: keymr, NoRaw: noraw}
+// GetABlock requests a specific ABlock from the factomd API
+func GetABlock(keymr string) (ablock *ABlock, err error) {
+	params := keyMRRequest{KeyMR: keymr, NoRaw: true}
 	req := NewJSON2Request("admin-block", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
 		return
 	}
 	if resp.Error != nil {
-		return nil, nil, resp.Error
+		return nil, resp.Error
 	}
 
 	// create a wraper construct for the ECBlock API return
 	wrap := new(struct {
-		ABlock  *ABlock `json:"ablock"`
-		RawData string  `json:"rawdata"`
+		ABlock *ABlock `json:"ablock"`
 	})
 
 	err = json.Unmarshal(resp.JSONResult(), wrap)
@@ -624,61 +623,27 @@ func getABlock(keymr string, noraw bool) (ablock *ABlock, raw []byte, err error)
 		return
 	}
 
-	raw, err = hex.DecodeString(wrap.RawData)
-	if err != nil {
-		return
-	}
-
-	return wrap.ABlock, raw, nil
+	return wrap.ABlock, nil
 }
 
-// GetABlock requests a specific ABlock from the factomd API with the raw data
-func GetABlock(keymr string) (ablock *ABlock, raw []byte, err error) {
-	return getABlock(keymr, false)
-}
-
-// GetSimpleABlock requests a specific ABlock from the factomd API without the raw data
-func GetSimpleABlock(keymr string) (ablock *ABlock, err error) {
-	ablock, _, err = getABlock(keymr, true)
-	return
-}
-
-func getABlockByHeight(height int64, noraw bool) (ablock *ABlock, raw []byte, err error) {
-	params := heightRequest{Height: height, NoRaw: noraw}
+// GetABlockByHeight requests an ABlock of a specific height from the factomd
+func GetABlockByHeight(height int64) (ablock *ABlock, err error) {
+	params := heightRequest{Height: height, NoRaw: true}
 	req := NewJSON2Request("ablock-by-height", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
 		return
 	}
 	if resp.Error != nil {
-		return nil, nil, resp.Error
+		return nil, resp.Error
 	}
 
 	wrap := new(struct {
-		ABlock  *ABlock `json:"ablock"`
-		RawData string  `json:"rawdata"`
+		ABlock *ABlock `json:"ablock"`
 	})
 	if err = json.Unmarshal(resp.JSONResult(), wrap); err != nil {
 		return
 	}
 
-	raw, err = hex.DecodeString(wrap.RawData)
-	if err != nil {
-		return
-	}
-
-	return wrap.ABlock, raw, nil
-}
-
-// GetABlockByHeight requests an ABlock of a specific height from the factomd
-// API with the raw data
-func GetABlockByHeight(height int64) (ablock *ABlock, raw []byte, err error) {
-	return getABlockByHeight(height, false)
-}
-
-// GetSimpleABlockByHeight requests an ABlock of a specific height from the factomd
-// API without the raw data
-func GetSimpleABlockByHeight(height int64) (ablock *ABlock, err error) {
-	ablock, _, err = getABlockByHeight(height, false)
-	return
+	return wrap.ABlock, nil
 }

--- a/ablock.go
+++ b/ablock.go
@@ -602,8 +602,7 @@ func (a *AdminAddAuthorityEfficiency) String() string {
 	return s
 }
 
-// GetABlock requests a specific ABlock from the factomd API.
-func GetABlock(keymr string) (ablock *ABlock, raw []byte, err error) {
+func getABlock(keymr string, noraw bool) (ablock *ABlock, raw []byte, err error) {
 	params := keyMRRequest{KeyMR: keymr}
 	req := NewJSON2Request("admin-block", APICounter(), params)
 	resp, err := factomdRequest(req)
@@ -633,10 +632,19 @@ func GetABlock(keymr string) (ablock *ABlock, raw []byte, err error) {
 	return wrap.ABlock, raw, nil
 }
 
-// GetABlockByHeight requests an ABlock of a specific height from the factomd
-// API.
-func GetABlockByHeight(height int64) (ablock *ABlock, raw []byte, err error) {
-	params := heightRequest{Height: height}
+// GetABlock requests a specific ABlock from the factomd API with the raw data
+func GetABlock(keymr string) (ablock *ABlock, raw []byte, err error) {
+	return getABlock(keymr, false)
+}
+
+// GetSimpleABlock requests a specific ABlock from the factomd API without the raw data
+func GetSimpleABlock(keymr string) (ablock *ABlock, err error) {
+	ablock, _, err = getABlock(keymr, true)
+	return
+}
+
+func getABlockByHeight(height int64, noraw bool) (ablock *ABlock, raw []byte, err error) {
+	params := heightRequest{Height: height, NoRaw: noraw}
 	req := NewJSON2Request("ablock-by-height", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
@@ -660,4 +668,17 @@ func GetABlockByHeight(height int64) (ablock *ABlock, raw []byte, err error) {
 	}
 
 	return wrap.ABlock, raw, nil
+}
+
+// GetABlockByHeight requests an ABlock of a specific height from the factomd
+// API with the raw data
+func GetABlockByHeight(height int64) (ablock *ABlock, raw []byte, err error) {
+	return getABlockByHeight(height, false)
+}
+
+// GetSimpleABlockByHeight requests an ABlock of a specific height from the factomd
+// API without the raw data
+func GetSimpleABlockByHeight(height int64) (ablock *ABlock, err error) {
+	ablock, _, err = getABlockByHeight(height, false)
+	return
 }

--- a/ablock.go
+++ b/ablock.go
@@ -603,7 +603,7 @@ func (a *AdminAddAuthorityEfficiency) String() string {
 }
 
 func getABlock(keymr string, noraw bool) (ablock *ABlock, raw []byte, err error) {
-	params := keyMRRequest{KeyMR: keymr}
+	params := keyMRRequest{KeyMR: keymr, NoRaw: noraw}
 	req := NewJSON2Request("admin-block", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {

--- a/ablock_test.go
+++ b/ablock_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 
 	. "github.com/FactomProject/factom"
 
@@ -77,6 +78,15 @@ func TestGetABlock(t *testing.T) {
 	}
 	t.Log("ABlock:", ab)
 	t.Log(fmt.Sprintf("Raw: %x\n", raw))
+
+	ab2, err := GetSimpleABlock("e7eb4bda495dbe7657cae1525b6be78bd2fdbad952ebde506b6a97e1cf8f431e")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(ab, ab2) {
+		t.Error("Response of ABlock from GetABlock and GetSimpleABlock did not match")
+	}
 }
 
 func TestGetABlockByHeight(t *testing.T) {
@@ -126,4 +136,13 @@ func TestGetABlockByHeight(t *testing.T) {
 	}
 	t.Log("ABlock:", ab)
 	t.Log(fmt.Sprintf("Raw: %x\n", raw))
+
+	ab2, err := GetSimpleABlockByHeight(20000)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(ab, ab2) {
+		t.Error("Response of ABlock from GetABlockByHeight and GetSimpleABlockByHeight did not match")
+	}
 }

--- a/ablock_test.go
+++ b/ablock_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 
 	. "github.com/FactomProject/factom"
 
@@ -72,21 +71,11 @@ func TestGetABlock(t *testing.T) {
 
 	SetFactomdServer(ts.URL[7:])
 
-	ab, raw, err := GetABlock("e7eb4bda495dbe7657cae1525b6be78bd2fdbad952ebde506b6a97e1cf8f431e")
+	ab, err := GetABlock("e7eb4bda495dbe7657cae1525b6be78bd2fdbad952ebde506b6a97e1cf8f431e")
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log("ABlock:", ab)
-	t.Log(fmt.Sprintf("Raw: %x\n", raw))
-
-	ab2, err := GetSimpleABlock("e7eb4bda495dbe7657cae1525b6be78bd2fdbad952ebde506b6a97e1cf8f431e")
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(ab, ab2) {
-		t.Error("Response of ABlock from GetABlock and GetSimpleABlock did not match")
-	}
 }
 
 func TestGetABlockByHeight(t *testing.T) {
@@ -130,19 +119,9 @@ func TestGetABlockByHeight(t *testing.T) {
 
 	SetFactomdServer(ts.URL[7:])
 
-	ab, raw, err := GetABlockByHeight(20000)
+	ab, err := GetABlockByHeight(20000)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log("ABlock:", ab)
-	t.Log(fmt.Sprintf("Raw: %x\n", raw))
-
-	ab2, err := GetSimpleABlockByHeight(20000)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(ab, ab2) {
-		t.Error("Response of ABlock from GetABlockByHeight and GetSimpleABlockByHeight did not match")
-	}
 }

--- a/byHeight.go
+++ b/byHeight.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 )
 
-
-
 type JStruct struct {
 	data []byte
 }
@@ -57,7 +55,7 @@ func (f *BlockByHeightRawResponse) String() string {
 // GetBlockByHeightRaw fetches the specified block type by height
 // Deprecated: use ablock, dblock, eblock, ecblock and fblock instead.
 func GetBlockByHeightRaw(blockType string, height int64) (*BlockByHeightRawResponse, error) {
-	params := heightRequest{Height: height}
+	params := heightRequest{Height: height, NoRaw: false} // include raw
 	req := NewJSON2Request(fmt.Sprintf("%vblock-by-height", blockType), APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {

--- a/dblock.go
+++ b/dblock.go
@@ -68,7 +68,7 @@ func (db *DBlock) String() string {
 // GetDBlock requests a Directory Block by its Key Merkle Root from the factomd
 func GetDBlock(keymr string) (dblock *DBlock, err error) {
 	params := keyMRRequest{KeyMR: keymr}
-	req := NewJSON2Request("directory-block", APICounter(), params) // doesn't have a "no raw" request
+	req := NewJSON2Request("directory-block", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
 		return

--- a/dblock_test.go
+++ b/dblock_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 
 	. "github.com/FactomProject/factom"
 
@@ -67,6 +68,15 @@ func TestGetDBlockByHeight(t *testing.T) {
 	}
 	t.Log("dblock:", d)
 	t.Log(fmt.Sprintf("raw: %x\n", raw))
+
+	d2, err := GetSimpleDBlockByHeight(100)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(d, d2) {
+		t.Error("Response of DBlock from GetDBlockByHeight and GetSimpleDBlockByHeight did not match")
+	}
 }
 
 func TestGetDBlockHead(t *testing.T) {

--- a/dblock_test.go
+++ b/dblock_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 
 	. "github.com/FactomProject/factom"
 
@@ -62,21 +61,11 @@ func TestGetDBlockByHeight(t *testing.T) {
 
 	SetFactomdServer(ts.URL[7:])
 
-	d, raw, err := GetDBlockByHeight(100)
+	d, err := GetDBlockByHeight(100)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log("dblock:", d)
-	t.Log(fmt.Sprintf("raw: %x\n", raw))
-
-	d2, err := GetSimpleDBlockByHeight(100)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(d, d2) {
-		t.Error("Response of DBlock from GetDBlockByHeight and GetSimpleDBlockByHeight did not match")
-	}
 }
 
 func TestGetDBlockHead(t *testing.T) {

--- a/ecblock.go
+++ b/ecblock.go
@@ -350,82 +350,48 @@ func (e *ECBalanceIncrease) String() string {
 	return s
 }
 
-func getECBlock(keymr string, noraw bool) (ecblock *ECBlock, raw []byte, err error) {
-	params := keyMRRequest{KeyMR: keymr, NoRaw: noraw}
+// GetECBlock requests a specified Entry Credit Block from the factomd API
+func GetECBlock(keymr string) (ecblock *ECBlock, err error) {
+	params := keyMRRequest{KeyMR: keymr, NoRaw: true}
 	req := NewJSON2Request("entrycredit-block", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
 		return
 	}
 	if resp.Error != nil {
-		return nil, nil, resp.Error
+		return nil, resp.Error
 	}
 
 	// create a wraper construct for the ECBlock API return
 	wrap := new(struct {
 		ECBlock *ECBlock `json:"ecblock"`
-		RawData string   `json:"rawdata"`
 	})
 	err = json.Unmarshal(resp.JSONResult(), wrap)
 	if err != nil {
 		return
 	}
 
-	raw, err = hex.DecodeString(wrap.RawData)
-	if err != nil {
-		return
-	}
-
-	return wrap.ECBlock, raw, nil
+	return wrap.ECBlock, nil
 }
 
-// GetECBlock requests a specified Entry Credit Block from the factomd API with the raw data
-func GetECBlock(keymr string) (ecblock *ECBlock, raw []byte, err error) {
-	return getECBlock(keymr, false)
-}
-
-// GetSimpleECBlock requests a specified Entry Credit Block from the factomd API without the raw data
-func GetSimpleECBlock(keymr string) (ecblock *ECBlock, err error) {
-	ecblock, _, err = getECBlock(keymr, true)
-	return
-}
-
-func getECBlockByHeight(height int64, noraw bool) (ecblock *ECBlock, raw []byte, err error) {
-	params := heightRequest{Height: height, NoRaw: noraw}
+// GetECBlockByHeight request an Entry Credit Block of a given height
+func GetECBlockByHeight(height int64) (ecblock *ECBlock, err error) {
+	params := heightRequest{Height: height, NoRaw: true}
 	req := NewJSON2Request("ecblock-by-height", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
 		return
 	}
 	if resp.Error != nil {
-		return nil, nil, resp.Error
+		return nil, resp.Error
 	}
 
 	wrap := new(struct {
 		ECBlock *ECBlock `json:"ecblock"`
-		RawData string   `json:"rawdata"`
 	})
 	if err = json.Unmarshal(resp.JSONResult(), wrap); err != nil {
 		return
 	}
 
-	raw, err = hex.DecodeString(wrap.RawData)
-	if err != nil {
-		return
-	}
-
-	return wrap.ECBlock, raw, nil
-}
-
-// GetECBlockByHeight request an Entry Credit Block of a given height from the
-// factomd API with the raw data
-func GetECBlockByHeight(height int64) (ecblock *ECBlock, raw []byte, err error) {
-	return getECBlockByHeight(height, false)
-}
-
-// GetECBlockByHeight request an Entry Credit Block of a given height from the
-// factomd API without the raw data
-func GetSimpleECBlockByHeight(height int64) (ecblock *ECBlock, err error) {
-	ecblock, _, err = getECBlockByHeight(height, true)
-	return
+	return wrap.ECBlock, nil
 }

--- a/ecblock.go
+++ b/ecblock.go
@@ -350,9 +350,8 @@ func (e *ECBalanceIncrease) String() string {
 	return s
 }
 
-// GetECBlock requests a specified Entry Credit Block from the factomd API.
-func GetECBlock(keymr string) (ecblock *ECBlock, raw []byte, err error) {
-	params := keyMRRequest{KeyMR: keymr}
+func getECBlock(keymr string, noraw bool) (ecblock *ECBlock, raw []byte, err error) {
+	params := keyMRRequest{KeyMR: keymr, NoRaw: noraw}
 	req := NewJSON2Request("entrycredit-block", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
@@ -380,10 +379,19 @@ func GetECBlock(keymr string) (ecblock *ECBlock, raw []byte, err error) {
 	return wrap.ECBlock, raw, nil
 }
 
-// GetECBlockByHeight request an Entry Credit Block of a given height from the
-// factomd API.
-func GetECBlockByHeight(height int64) (ecblock *ECBlock, raw []byte, err error) {
-	params := heightRequest{Height: height}
+// GetECBlock requests a specified Entry Credit Block from the factomd API with the raw data
+func GetECBlock(keymr string) (ecblock *ECBlock, raw []byte, err error) {
+	return getECBlock(keymr, false)
+}
+
+// GetSimpleECBlock requests a specified Entry Credit Block from the factomd API without the raw data
+func GetSimpleECBlock(keymr string) (ecblock *ECBlock, err error) {
+	ecblock, _, err = getECBlock(keymr, true)
+	return
+}
+
+func getECBlockByHeight(height int64, noraw bool) (ecblock *ECBlock, raw []byte, err error) {
+	params := heightRequest{Height: height, NoRaw: noraw}
 	req := NewJSON2Request("ecblock-by-height", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
@@ -407,4 +415,17 @@ func GetECBlockByHeight(height int64) (ecblock *ECBlock, raw []byte, err error) 
 	}
 
 	return wrap.ECBlock, raw, nil
+}
+
+// GetECBlockByHeight request an Entry Credit Block of a given height from the
+// factomd API with the raw data
+func GetECBlockByHeight(height int64) (ecblock *ECBlock, raw []byte, err error) {
+	return getECBlockByHeight(height, false)
+}
+
+// GetECBlockByHeight request an Entry Credit Block of a given height from the
+// factomd API without the raw data
+func GetSimpleECBlockByHeight(height int64) (ecblock *ECBlock, err error) {
+	ecblock, _, err = getECBlockByHeight(height, true)
+	return
 }

--- a/ecblock_test.go
+++ b/ecblock_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 
 	. "github.com/FactomProject/factom"
 
@@ -127,6 +128,15 @@ func TestGetECBlock(t *testing.T) {
 	}
 	t.Log("ECBlock: ", ecb)
 	t.Log(fmt.Sprintf("raw: %x\n", raw))
+
+	ecb2, err := GetSimpleECBlock("a7baaa24e477a0acef165461d70ec94ff3f33ad15562ecbe937967a761929a17")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(ecb, ecb2) {
+		t.Error("Response of ECBlock from GetECBlock and GetSimpleECBlock did not match")
+	}
 }
 
 func TestGetECBlockByHeight(t *testing.T) {
@@ -218,4 +228,13 @@ func TestGetECBlockByHeight(t *testing.T) {
 	}
 	t.Log("ECBlock: ", ecb)
 	t.Log(fmt.Sprintf("raw: %x\n", raw))
+
+	ecb2, err := GetSimpleECBlockByHeight(10199)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(ecb, ecb2) {
+		t.Error("Response of ECBlock from GetECBlockByHeight and GetSimpleECBlockByHeight did not match")
+	}
 }

--- a/ecblock_test.go
+++ b/ecblock_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 
 	. "github.com/FactomProject/factom"
 
@@ -122,21 +121,12 @@ func TestGetECBlock(t *testing.T) {
 
 	SetFactomdServer(ts.URL[7:])
 
-	ecb, raw, err := GetECBlock("a7baaa24e477a0acef165461d70ec94ff3f33ad15562ecbe937967a761929a17")
+	ecb, err := GetECBlock("a7baaa24e477a0acef165461d70ec94ff3f33ad15562ecbe937967a761929a17")
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log("ECBlock: ", ecb)
-	t.Log(fmt.Sprintf("raw: %x\n", raw))
 
-	ecb2, err := GetSimpleECBlock("a7baaa24e477a0acef165461d70ec94ff3f33ad15562ecbe937967a761929a17")
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(ecb, ecb2) {
-		t.Error("Response of ECBlock from GetECBlock and GetSimpleECBlock did not match")
-	}
 }
 
 func TestGetECBlockByHeight(t *testing.T) {
@@ -222,19 +212,9 @@ func TestGetECBlockByHeight(t *testing.T) {
 
 	SetFactomdServer(ts.URL[7:])
 
-	ecb, raw, err := GetECBlockByHeight(10199)
+	ecb, err := GetECBlockByHeight(10199)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log("ECBlock: ", ecb)
-	t.Log(fmt.Sprintf("raw: %x\n", raw))
-
-	ecb2, err := GetSimpleECBlockByHeight(10199)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(ecb, ecb2) {
-		t.Error("Response of ECBlock from GetECBlockByHeight and GetSimpleECBlockByHeight did not match")
-	}
 }

--- a/fblock.go
+++ b/fblock.go
@@ -5,7 +5,6 @@
 package factom
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 )
@@ -44,84 +43,48 @@ func (f *FBlock) String() string {
 	return s
 }
 
-func getFBlock(keymr string, noraw bool) (fblock *FBlock, raw []byte, err error) {
-	params := keyMRRequest{KeyMR: keymr, NoRaw: noraw}
+// GetFBlock requests a specified Factoid Block from factomd by its keymr
+func GetFBlock(keymr string) (fblock *FBlock, err error) {
+	params := keyMRRequest{KeyMR: keymr, NoRaw: true}
 	req := NewJSON2Request("factoid-block", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
 		return
 	}
 	if resp.Error != nil {
-		return nil, nil, resp.Error
+		return nil, resp.Error
 	}
 
 	// Create temporary struct to unmarshal json object
 	wrap := new(struct {
-		FBlock  *FBlock `json:"fblock"`
-		RawData string  `json:"rawdata"`
+		FBlock *FBlock `json:"fblock"`
 	})
 
 	if err = json.Unmarshal(resp.JSONResult(), wrap); err != nil {
 		return
 	}
 
-	raw, err = hex.DecodeString(wrap.RawData)
-	if err != nil {
-		return
-	}
-
-	return wrap.FBlock, raw, nil
+	return wrap.FBlock, nil
 }
 
-// GetFBlock requests a specified Factoid Block from factomd. It returns the
-// FBlock struct, the raw binary FBlock, and an error if present.
-func GetFBlock(keymr string) (fblock *FBlock, raw []byte, err error) {
-	return getFBlock(keymr, false)
-}
-
-// GetSimpleFBlock requests a specified Factoid Block from factomd. It returns the
-// FBlock struct, and an error if present.
-func GetSimpleFBlock(keymr string) (fblock *FBlock, err error) {
-	fblock, _, err = getFBlock(keymr, true)
-	return
-}
-
-func getFBlockByHeight(height int64, noraw bool) (fblock *FBlock, raw []byte, err error) {
-	params := heightRequest{Height: height, NoRaw: noraw}
+// GetFBlockByHeight requests a specified Factoid Block from factomd by its height
+func GetFBlockByHeight(height int64) (fblock *FBlock, err error) {
+	params := heightRequest{Height: height, NoRaw: true}
 	req := NewJSON2Request("fblock-by-height", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
 		return
 	}
 	if resp.Error != nil {
-		return nil, nil, resp.Error
+		return nil, resp.Error
 	}
 
 	wrap := new(struct {
-		FBlock  *FBlock `json:"fblock"`
-		RawData string  `json:"rawdata"`
+		FBlock *FBlock `json:"fblock"`
 	})
 	if err = json.Unmarshal(resp.JSONResult(), wrap); err != nil {
 		return
 	}
 
-	raw, err = hex.DecodeString(wrap.RawData)
-	if err != nil {
-		return
-	}
-
-	return wrap.FBlock, raw, nil
-}
-
-// GetFBlockByHeight requests a specified Factoid Block from factomd, returning
-// the FBlock struct, the raw binary FBlock, and an error if present.
-func GetFBlockByHeight(height int64) (fblock *FBlock, raw []byte, err error) {
-	return getFBlockByHeight(height, false)
-}
-
-// GetSimpleFBlockByHeight requests a specified Factoid Block from factomd, returning
-// the FBlock struct, the raw binary FBlock, and an error if present.
-func GetSimpleFBlockByHeight(height int64) (fblock *FBlock, err error) {
-	fblock, _, err = getFBlockByHeight(height, true)
-	return
+	return wrap.FBlock, nil
 }

--- a/fblock.go
+++ b/fblock.go
@@ -44,10 +44,8 @@ func (f *FBlock) String() string {
 	return s
 }
 
-// GetFblock requests a specified Factoid Block from factomd. It returns the
-// FBlock struct, the raw binary FBlock, and an error if present.
-func GetFBlock(keymr string) (fblock *FBlock, raw []byte, err error) {
-	params := keyMRRequest{KeyMR: keymr}
+func getFBlock(keymr string, noraw bool) (fblock *FBlock, raw []byte, err error) {
+	params := keyMRRequest{KeyMR: keymr, NoRaw: noraw}
 	req := NewJSON2Request("factoid-block", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
@@ -75,10 +73,21 @@ func GetFBlock(keymr string) (fblock *FBlock, raw []byte, err error) {
 	return wrap.FBlock, raw, nil
 }
 
-// GetFBlockByHeight requests a specified Factoid Block from factomd, returning
-// the FBlock struct, the raw binary FBlock, and an error if present.
-func GetFBlockByHeight(height int64) (ablock *FBlock, raw []byte, err error) {
-	params := heightRequest{Height: height}
+// GetFBlock requests a specified Factoid Block from factomd. It returns the
+// FBlock struct, the raw binary FBlock, and an error if present.
+func GetFBlock(keymr string) (fblock *FBlock, raw []byte, err error) {
+	return getFBlock(keymr, false)
+}
+
+// GetSimpleFBlock requests a specified Factoid Block from factomd. It returns the
+// FBlock struct, and an error if present.
+func GetSimpleFBlock(keymr string) (fblock *FBlock, err error) {
+	fblock, _, err = getFBlock(keymr, true)
+	return
+}
+
+func getFBlockByHeight(height int64, noraw bool) (fblock *FBlock, raw []byte, err error) {
+	params := heightRequest{Height: height, NoRaw: noraw}
 	req := NewJSON2Request("fblock-by-height", APICounter(), params)
 	resp, err := factomdRequest(req)
 	if err != nil {
@@ -102,4 +111,17 @@ func GetFBlockByHeight(height int64) (ablock *FBlock, raw []byte, err error) {
 	}
 
 	return wrap.FBlock, raw, nil
+}
+
+// GetFBlockByHeight requests a specified Factoid Block from factomd, returning
+// the FBlock struct, the raw binary FBlock, and an error if present.
+func GetFBlockByHeight(height int64) (fblock *FBlock, raw []byte, err error) {
+	return getFBlockByHeight(height, false)
+}
+
+// GetSimpleFBlockByHeight requests a specified Factoid Block from factomd, returning
+// the FBlock struct, the raw binary FBlock, and an error if present.
+func GetSimpleFBlockByHeight(height int64) (fblock *FBlock, err error) {
+	fblock, _, err = getFBlockByHeight(height, true)
+	return
 }

--- a/fblock_test.go
+++ b/fblock_test.go
@@ -7,6 +7,7 @@ package factom_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"encoding/json"
@@ -105,6 +106,15 @@ func TestGetFBlock(t *testing.T) {
 	}
 	t.Log(fb)
 	t.Log(fmt.Printf("%x\n", raw))
+
+	fb2, err := GetSimpleFBlock("cfcac07b29ccfa413aeda646b5d386006468189939dfdfa6415b97cc35f2ea1a")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(fb, fb2) {
+		t.Error("Response of FBlock from GetFBlock and GetSimpleFBlock did not match")
+	}
 }
 
 func TestGetFBlockByHeight(t *testing.T) {
@@ -181,4 +191,13 @@ func TestGetFBlockByHeight(t *testing.T) {
 	}
 	t.Log("FBlock:", ab)
 	t.Log(fmt.Sprintf("Raw: %x\n", raw))
+
+	ab2, err := GetSimpleFBlockByHeight(20000)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(ab, ab2) {
+		t.Error("Response of FBlock from GetFBlockByHeight and GetSimpleFBlockByHeight did not match")
+	}
 }

--- a/fblock_test.go
+++ b/fblock_test.go
@@ -7,7 +7,6 @@ package factom_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"encoding/json"
@@ -100,21 +99,11 @@ func TestGetFBlock(t *testing.T) {
 
 	SetFactomdServer(ts.URL[7:])
 
-	fb, raw, err := GetFBlock("cfcac07b29ccfa413aeda646b5d386006468189939dfdfa6415b97cc35f2ea1a")
+	fb, err := GetFBlock("cfcac07b29ccfa413aeda646b5d386006468189939dfdfa6415b97cc35f2ea1a")
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log(fb)
-	t.Log(fmt.Printf("%x\n", raw))
-
-	fb2, err := GetSimpleFBlock("cfcac07b29ccfa413aeda646b5d386006468189939dfdfa6415b97cc35f2ea1a")
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(fb, fb2) {
-		t.Error("Response of FBlock from GetFBlock and GetSimpleFBlock did not match")
-	}
 }
 
 func TestGetFBlockByHeight(t *testing.T) {
@@ -185,19 +174,9 @@ func TestGetFBlockByHeight(t *testing.T) {
 
 	SetFactomdServer(ts.URL[7:])
 
-	ab, raw, err := GetFBlockByHeight(20000)
+	ab, err := GetFBlockByHeight(20000)
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log("FBlock:", ab)
-	t.Log(fmt.Sprintf("Raw: %x\n", raw))
-
-	ab2, err := GetSimpleFBlockByHeight(20000)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(ab, ab2) {
-		t.Error("Response of FBlock from GetFBlockByHeight and GetSimpleFBlockByHeight did not match")
-	}
 }

--- a/wallet/txdatabase.go
+++ b/wallet/txdatabase.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 
@@ -387,7 +388,7 @@ func fblockHead() (interfaces.IFBlock, error) {
 	if err != nil {
 		return nil, err
 	}
-	dblock, _, err := factom.GetDBlock(dbhead)
+	dblock, err := factom.GetDBlock(dbhead)
 	if err != nil {
 		return nil, err
 	}
@@ -406,25 +407,38 @@ func fblockHead() (interfaces.IFBlock, error) {
 }
 
 func getfblock(keymr string) (interfaces.IFBlock, error) {
-	_, raw, err := factom.GetFBlock(keymr)
+	raw, err := factom.GetRaw(keymr)
 	if err != nil {
 		return nil, err
 	}
+
 	return factoid.UnmarshalFBlock(raw)
 }
 
 func getfblockbyheight(height uint32) (interfaces.IFBlock, error) {
-	_, raw, err := factom.GetFBlockByHeight(int64(height))
+	resp, err := factom.GetBlockByHeightRaw("fblock", int64(height))
 	if err != nil {
 		return nil, err
 	}
+
+	raw, err := hex.DecodeString(resp.RawData)
+	if err != nil {
+		return nil, err
+	}
+
 	return factoid.UnmarshalFBlock(raw)
 }
 
 func getdblockbyheight(height uint32) (interfaces.IDirectoryBlock, error) {
-	_, raw, err := factom.GetDBlockByHeight(int64(height))
+	resp, err := factom.GetBlockByHeightRaw("dblock", int64(height))
 	if err != nil {
 		return nil, err
 	}
+
+	raw, err := hex.DecodeString(resp.RawData)
+	if err != nil {
+		return nil, err
+	}
+
 	return directoryBlock.UnmarshalDBlock(raw)
 }

--- a/wsapistructs.go
+++ b/wsapistructs.go
@@ -8,6 +8,7 @@ package factom
 
 type heightRequest struct {
 	Height int64 `json:"height"`
+	NoRaw  bool  `json:"noraw,omitempty"`
 }
 
 type replayRequest struct {
@@ -59,6 +60,7 @@ type importRequest struct {
 
 type keyMRRequest struct {
 	KeyMR string `json:"keymr"`
+	NoRaw bool   `json:"noraw,omitempty"`
 }
 
 type messageRequest struct {


### PR DESCRIPTION
Tandem PR with https://github.com/FactomProject/factomd/pull/996

This adds functions to the API to retrieve the various blocks without the raw component, making use of the above PR. Ideally, both are merged but this PR **will work on its own**, it just won't be any more efficient.

Each GetXBlock and GetXBlockByHeight function has a GetSimpleXBlock and GetSimpleXBlockByHeight counterpart with a different return signature. There are unit tests for all functions that check the return value is identical.